### PR TITLE
Implement an opus encoder and decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ The server's audio input is a named pipe `/tmp/snapfifo`. All data that is fed i
 
 How does is work
 ----------------
-The snapserver reads PCM chunks of 50ms duration from the pipe `/tmp/snapfifo`. The chunk is encoded and tagged with the local time
+The snapserver reads PCM chunks of 10ms duration from the pipe `/tmp/snapfifo`. The chunk is encoded and tagged with the local time
 * PCM: lossless uncompressed
 * FLAC: lossless compressed [default]
 * Vorbis: lossy compression
+* Opus: lossy low-latency compression
 
 The encoded chunk is sent via a TCP connection to the snapclients.
-Each client does continuos time synchronization with the server, so that the client is always aware of the local server time.  
-Every received chunk is first decoded and added to the client's chunk-buffer. Knowing the server's time, the chunk is played out using alsa at the appropriate time. Time deviations are corrected by 
+Each client does continuos time synchronization with the server, so that the client is always aware of the local server time.
+Every received chunk is first decoded and added to the client's chunk-buffer. Knowing the server's time, the chunk is played out using alsa at the appropriate time. Time deviations are corrected by
 * skipping parts or whole chunks
 * playing silence
 * playing faster/slower
@@ -33,7 +34,7 @@ Build snapcast by cd'ing into the snapcast src-root directory
 
     $ cd <MY_SNAPCAST_ROOT>
     $ make all
-    
+
 Install snapclient and/or snapserver. The client installation will ask you for the server's hostname or ip address
 
     $ sudo make installserver
@@ -65,22 +66,22 @@ Disable alsa audio output by commenting out this section:
     #       type            "alsa"
     #       name            "My ALSA Device"
     #       device          "hw:0,0"        # optional
-    #       format          "44100:16:2"    # optional
+    #       format          "48000:16:2"    # optional
     #       mixer_device    "default"       # optional
     #       mixer_control   "PCM"           # optional
     #       mixer_index     "0"             # optional
     #}
 
 Add a new audio output of the type "fifo", which will let mpd play audio into the named pipe `/tmp/snapfifo`.
-Make sure that the "format" setting is the same as the format setting of the snapserver (default is "44100:16:2", which should make resampling unnecessary in most cases)
+Make sure that the "format" setting is the same as the format setting of the snapserver (default is "48000:16:2", which should make resampling unnecessary in most cases)
 
     audio_output {
         type            "fifo"
         name            "my pipe"
-        path            "/tmp/snapfifo" 
-        format          "44100:16:2"
+        path            "/tmp/snapfifo"
+        format          "48000:16:2"
         mixer_type      "software"
-    } 
+    }
 
 To test your mpd installation, you can add a radio station by
 
@@ -93,7 +94,7 @@ On the server you could create a sink to route sound of your applications to the
 ```
 pacmd load-module module-pipe-sink file=/tmp/snapfifo
 ```
-    
+
 Roadmap
 -------
 * Support multiple streams ("Zones")

--- a/client/Makefile
+++ b/client/Makefile
@@ -8,9 +8,9 @@ else
 endif
 CC      = /usr/bin/g++
 CFLAGS  = -std=gnu++0x -static-libgcc -static-libstdc++ -Wall -Wno-unused-function -O3 -D_REENTRANT -DVERSION=\"$(VERSION)\" -I..
-LDFLAGS = -lrt -lpthread -lboost_system -lboost_program_options -lasound -logg -lvorbis -lvorbisenc -lFLAC -lavahi-client -lavahi-common
+LDFLAGS = -lrt -lpthread -lboost_system -lboost_program_options -lasound -logg -lopus -lvorbis -lvorbisenc -lFLAC -lavahi-client -lavahi-common
 
-OBJ = snapClient.o stream.o alsaPlayer.o clientConnection.o timeProvider.o oggDecoder.o pcmDecoder.o flacDecoder.o controller.o browseAvahi.o ../message/pcmChunk.o ../common/log.o ../message/sampleFormat.o
+OBJ = snapClient.o stream.o alsaPlayer.o clientConnection.o timeProvider.o opusDecoder.o oggDecoder.o pcmDecoder.o flacDecoder.o controller.o browseAvahi.o ../message/pcmChunk.o ../common/log.o ../message/sampleFormat.o
 BIN = snapclient
 
 all:	$(TARGET)

--- a/client/controller.cpp
+++ b/client/controller.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <unistd.h>
 #include "oggDecoder.h"
+#include "opusDecoder.h"
 #include "pcmDecoder.h"
 #include "flacDecoder.h"
 #include "alsaPlayer.h"
@@ -116,6 +117,8 @@ void Controller::worker()
 			logO << "Codec: " << headerChunk->codec << "\n";
 			if (headerChunk->codec == "ogg")
 				decoder_ = new OggDecoder();
+			else if (headerChunk->codec == "opus")
+				decoder_ = new OpusDecoderWrapper();
 			else if (headerChunk->codec == "pcm")
 				decoder_ = new PcmDecoder();
 			else if (headerChunk->codec == "flac")

--- a/client/opusDecoder.cpp
+++ b/client/opusDecoder.cpp
@@ -1,0 +1,76 @@
+/***
+	This file is part of snapcast
+	Copyright (C) 2015  Hannes Ellinger
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "opusDecoder.h"
+#include "common/log.h"
+
+
+OpusDecoderWrapper::OpusDecoderWrapper() : Decoder() {
+	int error;
+
+	dec = opus_decoder_create(48000, 2, &error); // fixme
+	if(error != 0) {
+		logE << "Failed to initialize opus decoder: " << error << '\n';
+		logE << " Rate:     " << 48000 << '\n';
+		logE << " Channels: " << 2 << '\n';
+	}
+}
+
+
+OpusDecoderWrapper::~OpusDecoderWrapper() {}
+
+
+bool OpusDecoderWrapper::decode(msg::PcmChunk* chunk) {
+	int samples = 480;
+	// reserve space for decoded audio
+	opus_int16 pcm[samples*2];
+
+	msg::PcmChunk* decodedChunk = new msg::PcmChunk();
+	decodedChunk->payloadSize = samples*4;
+	decodedChunk->payload = (char*)realloc(decodedChunk->payload, decodedChunk->payloadSize);
+
+	// decode
+	int frame_size = opus_decode(dec, (unsigned char*)chunk->payload, chunk->payloadSize, pcm, samples, 0);
+	if (frame_size < 0) {
+		logE << "Failed to decode chunk: " << frame_size << '\n';
+		logE << " IN size:  " << chunk->payloadSize << '\n';
+		logE << " OUT size: " << decodedChunk->payloadSize << '\n';
+	}
+	else {
+		// logD << "Decoded chunk: size " << chunk->payloadSize << " bytes, decoded " << frame_size << " bytes" << '\n';
+
+		// copy encoded data to chunk
+		chunk->payloadSize = samples*4;
+		chunk->payload = (char*)realloc(chunk->payload, chunk->payloadSize);
+
+		// uninterleave audio
+		for(int i=0; i<samples*2; i++) {
+			chunk->payload[2*i+1] = (char)(pcm[i] >> 8);
+			chunk->payload[2*i] = (char)(pcm[i] & 0x00ff);
+		}
+
+	}
+
+	return true;
+}
+
+
+bool OpusDecoderWrapper::setHeader(msg::Header* chunk)
+{
+	return true;
+}

--- a/client/opusDecoder.h
+++ b/client/opusDecoder.h
@@ -1,0 +1,36 @@
+/***
+	This file is part of snapcast
+	Copyright (C) 2015  Hannes Ellinger
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+#include "decoder.h"
+#include <opus/opus.h>
+
+
+class OpusDecoderWrapper : public Decoder
+{
+public:
+	OpusDecoderWrapper();
+	~OpusDecoderWrapper();
+	bool decode(msg::PcmChunk* chunk);
+	bool setHeader(msg::Header* chunk);
+
+private:
+
+	OpusDecoder *dec;
+};

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,9 +1,9 @@
 VERSION = 0.2
 CC      = /usr/bin/g++
 CFLAGS  = -std=gnu++0x -Wall -Wno-unused-function -O3 -D_REENTRANT -DVERSION=\"$(VERSION)\" -I..
-LDFLAGS = -lrt -lpthread -lboost_system -lboost_program_options -lvorbis -lvorbisenc -logg -lFLAC -lavahi-client -lavahi-common
+LDFLAGS = -lrt -lpthread -lboost_system -lboost_program_options -lopus -lvorbis -lvorbisenc -logg -lFLAC -lavahi-client -lavahi-common
 
-OBJ = snapServer.o controlServer.o flacEncoder.o pcmEncoder.o oggEncoder.o serverSession.o publishAvahi.o ../common/log.o ../message/pcmChunk.o ../message/sampleFormat.o
+OBJ = snapServer.o controlServer.o flacEncoder.o pcmEncoder.o opusEncoder.o oggEncoder.o serverSession.o publishAvahi.o ../common/log.o ../message/pcmChunk.o ../message/sampleFormat.o
 BIN = snapserver
 
 all:	server
@@ -30,4 +30,4 @@ uninstall:
 	rm -f /usr/sbin/snapserver; \
 	rm -f /etc/init.d/snapserver; \
 	update-rc.d -f snapserver remove; \
-	
+

--- a/server/opusEncoder.cpp
+++ b/server/opusEncoder.cpp
@@ -1,0 +1,67 @@
+/***
+	This file is part of snapcast
+	Copyright (C) 2015  Hannes Ellinger
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "opusEncoder.h"
+#include "common/log.h"
+
+
+OpusEncoderWrapper::OpusEncoderWrapper(const msg::SampleFormat& format) : Encoder(format)
+{
+	int error;
+	headerChunk = new msg::Header("opus");
+	enc = opus_encoder_create(format.rate, format.channels, OPUS_APPLICATION_RESTRICTED_LOWDELAY, &error);
+	if(error != 0) {
+		logE << "Failed to initialize opus encoder: " << error << '\n';
+		logE << " Rate:     " << format.rate << '\n';
+		logE << " Channels: " << format.channels << '\n';
+	}
+}
+
+
+double OpusEncoderWrapper::encode(msg::PcmChunk* chunk)
+{
+	int samples = chunk->payloadSize/4;
+	opus_int16 pcm[samples*2];
+
+	unsigned char encoded[chunk->payloadSize];
+
+	// get 16 bit samples
+	for(int i=0; i<samples*2; i++)
+	{
+		pcm[i] = (opus_int16)(((opus_int16)chunk->payload[2*i+1] << 8) | (0x00ff & (opus_int16)chunk->payload[2*i]));
+	}
+
+	// encode
+	int len = opus_encode(enc, pcm, samples, encoded, chunk->payloadSize);
+	// logD << "Encoded: size " << chunk->payloadSize << " bytes, encoded: " << len << " bytes" << '\n';
+
+	if(len>0) {
+		// copy encoded data to chunk
+		chunk->payloadSize = len;
+		chunk->payload = (char*)realloc(chunk->payload, chunk->payloadSize);
+		memcpy(chunk->payload, encoded, len);
+	}
+	else {
+		logE << "Failed to encode chunk: " << len << '\n';
+		logE << " Frame size: " << samples/2 << '\n';
+		logE << " Max bytes:  " << chunk->payloadSize << '\n';
+	}
+
+	// return chunk duration
+	return (double)samples / ((double)sampleFormat.rate / 1000.);
+}

--- a/server/opusEncoder.h
+++ b/server/opusEncoder.h
@@ -1,0 +1,33 @@
+/***
+	This file is part of snapcast
+	Copyright (C) 2015  Hannes Ellinger
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+#include "encoder.h"
+#include <opus/opus.h>
+
+
+class OpusEncoderWrapper : public Encoder
+{
+public:
+	OpusEncoderWrapper(const msg::SampleFormat& format);
+	double encode(msg::PcmChunk* chunk);
+
+private:
+	OpusEncoder *enc;
+};


### PR DESCRIPTION
Opus is a modern open source codec for both, high quality and low latency applications. Thus it is perfect for a network audio distribution system like snapcast.

I have implemented an encoder and decoder and changed the default sample rate and chunk duration since opus does not allow 44100kHz. Allowed chunk sizes are 10ms or 20ms.

Please let me know if my patch needs modifications. I will be happy to adopt them.
