### PR TITLE
added primitive software volume control for client

### DIFF
--- a/.syntastic_cpp_config
+++ b/.syntastic_cpp_config
@@ -1,0 +1,7 @@
+-std=c++0x
+-Wall
+-Wno-unused-function
+-O3
+-pthread
+-DVERSION="$(VERSION)"
+-I..

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,21 @@ server:
 
 client:
 	$(MAKE) -C client
-	
+
 clean:
-	$(MAKE) clean -C client 
-	$(MAKE) clean -C server 
+	$(MAKE) clean -C client
+	$(MAKE) clean -C server
 	rm -f *~
-	
+
 installclient:
-	$(MAKE) install -C client 
+	$(MAKE) install -C client
 
 installserver:
-	$(MAKE) install -C server 
+	$(MAKE) install -C server
 
 uninstallclient:
-	$(MAKE) uninstall -C client 
+	$(MAKE) uninstall -C client
 
 uninstallserver:
-	$(MAKE) uninstall -C server 
-	
+	$(MAKE) uninstall -C server
+

--- a/client/Makefile
+++ b/client/Makefile
@@ -6,7 +6,7 @@ CXX     = /usr/bin/g++
 CFLAGS  = -std=c++0x -Wall -Wno-unused-function -O3 -pthread -DVERSION=\"$(VERSION)\" -I.. # -static-libgcc -static-libstdc++
 LDFLAGS = -lrt -lboost_system -lboost_program_options -lasound -logg -lvorbis -lvorbisenc -lFLAC -lavahi-client -lavahi-common
 
-OBJ = snapClient.o stream.o alsaPlayer.o clientConnection.o timeProvider.o decoder/oggDecoder.o decoder/pcmDecoder.o decoder/flacDecoder.o controller.o browseAvahi.o ../message/pcmChunk.o ../common/log.o ../message/sampleFormat.o
+OBJ = snapClient.o stream.o alsaPlayer.o clientConnection.o timeProvider.o decoder/oggDecoder.o decoder/pcmDecoder.o decoder/flacDecoder.o controller.o browseAvahi.o ../message/pcmChunk.o ../common/log.o ../message/sampleFormat.o ../server/publishAvahi.o
 BIN = snapclient
 
 all:	$(TARGET)

--- a/client/alsaPlayer.h
+++ b/client/alsaPlayer.h
@@ -27,27 +27,31 @@
 #include "stream.h"
 #include "pcmDevice.h"
 
-
 class Player
 {
 public:
-	Player(const PcmDevice& pcmDevice, Stream* stream);
+	Player(const PcmDevice& pcmDevice, Stream* stream, unsigned char volume);
 	virtual ~Player();
 	void start();
 	void stop();
 	static std::vector<PcmDevice> pcm_list(void);
+	unsigned char getVolume();
+	void setVolume(unsigned char volume);
 
 private:
+    void applyVolume();
 	void initAlsa();
 	void uninitAlsa();
 	void worker();
 	snd_pcm_t* handle_;
 	snd_pcm_uframes_t frames_;
 	char *buff_;
+	int buff_size_;
 	std::atomic<bool> active_;
 	Stream* stream_;
 	std::thread playerThread_;
 	PcmDevice pcmDevice_;
+	unsigned char volume_; //0 - 100 in percent, incoming stream has 100
 };
 
 

--- a/client/controller.h
+++ b/client/controller.h
@@ -26,7 +26,9 @@
 #include "clientConnection.h"
 #include "stream.h"
 #include "pcmDevice.h"
+#include "alsaPlayer.h"
 
+using boost::asio::ip::tcp;
 
 /// Forwards PCM data to the audio player
 /**
@@ -38,7 +40,7 @@ class Controller : public MessageReceiver
 {
 public:
 	Controller();
-	void start(const PcmDevice& pcmDevice, const std::string& ip, size_t port, size_t latency);
+	void start(const PcmDevice& pcmDevice, const std::string& ip, size_t port, size_t latency, unsigned char volume, size_t ctlport);
 	void stop();
 
 	/// Implementation of MessageReceiver.
@@ -55,15 +57,21 @@ private:
 	std::atomic<bool> active_;
 	std::thread* controllerThread_;
 	ClientConnection* clientConnection_;
+	Player* player_;
 	Stream* stream_;
 	std::string ip_;
 	std::shared_ptr<msg::SampleFormat> sampleFormat_;
 	Decoder* decoder_;
 	PcmDevice pcmDevice_;
 	size_t latency_;
+	unsigned char volume_;
 
 	std::exception exception_;
 	bool asyncException_;
+
+	void startCtlServer(size_t port);
+	void handleRequest(tcp::socket sock);
+	std::thread* acceptThread_;
 };
 
 

--- a/syncMpdSnapCastVol.sh
+++ b/syncMpdSnapCastVol.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#Example script that watches the MPD volume and sets the snapclient volume
+#accordingly via the remote control protocol. Set up MPD in the following way:
+#
+## Snapcast gets the audio stream unmodified
+# audio_output {
+#     type            "fifo"
+#     name            "snapcast"
+#     path            "/tmp/snapfifo"
+#     format          "44100:16:2"
+#     mixer_type      "null"
+# }
+## This dummy output allows to set the MPD volume without actually playing
+# audio_output {
+#     type            "pipe"
+#     name            "volume dummy"
+#     command         "cat >/dev/null"
+#     format          "44100:16:2"
+#     mixer_type      "software"
+# }
+#
+# Let this script run, and voila - you can set the volume of your MPD-local
+# snapcast client with any MPD client!
+
+mpd_host=localhost
+mpd_port=6600
+snapclient_host=localhost
+snapclient_port=3333
+
+oldvol=-1
+while true; do
+  vol=$(mpc -h $mpd_host -p $mpd_port volume | sed 's/[^0-9]*\([0-9]*\).*/\1/')
+  if [ "$oldvol" != "$vol" ]; then
+    oldvol=$vol
+    exec 3<>/dev/tcp/$snapclient_host/$snapclient_port
+    echo "volume set $vol" >&3
+    exec 3>&-
+  fi
+  sleep 0.5
+done


### PR DESCRIPTION
What do you think about this?

I think the remote control should have a textual protocol. One could of course add latency, zone/server changing, etc. in the same style. The advantage is, that such a format is good for scripting. See for example the syncMpdSnapCastVol.sh script - it can be used to make snapcast basically transparent.

I think each snapcast client should be able to set the volume separately, this should not be done on the server side, so the fifo MPD output should have a null mixer. Then, such a script can be used to still be able to change the volume on the same device. Using the software mixer as in your README example has the disadvantage that if I set the MPD volume low, then I get a physically silent stream on all clients (even if their volume is high), which is obviously not desireble.