### PR TITLE
Fix url for submodule flac

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/chriskohlhoff/asio.git
 [submodule "externals/flac"]
 	path = externals/flac
-	url = git://xiph.org/flac.git
+	url = https://git.xiph.org/flac.git


### PR DESCRIPTION
It seems that the repo url has changed. Unfortunately I got a connection reset by peer error on using the git protocol, thats why I switched to https.

> Cloning into 'externals/flac'...
fatal: read error: Connection reset by peer
fatal: clone of 'git://git.xiph.org/flac.git' into submodule path 'externals/flac' failed