### PR TITLE
Log exception on streamServer::start()

### DIFF
--- a/server/streamServer.cpp
+++ b/server/streamServer.cpp
@@ -379,8 +379,9 @@ void StreamServer::start()
 		acceptor_ = make_shared<tcp::acceptor>(*io_service_, tcp::endpoint(tcp::v4(), settings_.port));
 		startAccept();
 	}
-	catch (const std::exception&)
+	catch (const std::exception& e)
 	{
+		logS(kLogNotice) << "StreamServer::start: " << e.what() << endl;
 		stop();
 		throw;
 	}


### PR DESCRIPTION
I had to compile snapserver in debug and look at the stack-trace to actually figure out I was just plain dumb and had another instance running in another terminal tab. This little log will probably avoid frustration, at least to future me :-)