### PR TITLE
Adding ProcessType designation to the snapserver MacOS launchctl plist

### DIFF
--- a/server/debian/snapserver.plist
+++ b/server/debian/snapserver.plist
@@ -13,5 +13,7 @@
 		<true/>
 		<key>KeepAlive</key>
 		<true/>
+		<key>ProcessType</key>
+		<string>Interactive</string>
 	</dict>
 </plist>


### PR DESCRIPTION
Running `snapserver` directly in the terminal has been working great, however when I started using `launchctl` to manage it, the audio wouldn't load on my clients. Client logs looked like this (repeated ad infinitum):
```
2016-12-02 01-19-31 [out] Chunk: -7885	-7885	-7885	-7885	1	211
2016-12-02 01-19-31 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-31 [out] Sleep 16, age: -733, bufferDuration: 100
2016-12-02 01-19-31 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-31 [out] Sleep 16, age: -891, bufferDuration: 100
2016-12-02 01-19-31 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-31 [out] Sleep 16, age: -781, bufferDuration: 100
2016-12-02 01-19-31 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-32 [out] Sleep 16, age: -794, bufferDuration: 100
2016-12-02 01-19-32 [out] Chunk: -7942	-7942	-7942	-7942	1	153
2016-12-02 01-19-32 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-32 [out] Sleep 15, age: -853, bufferDuration: 100
2016-12-02 01-19-32 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-32 [out] Sleep 15, age: -812, bufferDuration: 100
2016-12-02 01-19-32 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-32 [out] Sleep 15, age: -725, bufferDuration: 100
2016-12-02 01-19-32 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-33 [out] Sleep 15, age: -884, bufferDuration: 100
2016-12-02 01-19-33 [out] Chunk: -8841	-8841	-8841	-8841	1	124
2016-12-02 01-19-33 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-33 [out] Sleep 15, age: -773, bufferDuration: 100
2016-12-02 01-19-33 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-33 [out] Sleep 15, age: -787, bufferDuration: 100
2016-12-02 01-19-33 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-33 [out] Sleep 15, age: -834, bufferDuration: 100
2016-12-02 01-19-33 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-33 [out] Sleep 15, age: -869, bufferDuration: 100
2016-12-02 01-19-33 [out] Failed to get chunk. Playing silence.
2016-12-02 01-19-34 [out] Sleep 15, age: -883, bufferDuration: 100
```
It seemed like launchctl may be throttling the server process, and after a bit of research I found the `ProcessType` designation for `launchd.plist` files. From `man launchd.plist`:
```
ProcessType <string>
     This optional key describes, at a high level, the intended purpose of the
     job.  The system will apply resource limits based on what kind of job it is.
     If left unspecified, the system will apply light resource limits to the job,
     throttling its CPU usage and I/O bandwidth.
```
The default `ProcessType` (when one is not specified) is `Standard`, and the type above that in priority is `Interactive`:
```
Interactive
           Interactive jobs run with the same resource limitations as apps, that
           is to say, none. Interactive jobs are critical to maintaining a
           responsive user experience, and this key should only be used if an
           app's ability to be responsive depends on it, and cannot be made Adap-
           tive.
```
After setting `ProcessType` to `Interactive` in my `snapserver` plist, I get great audio performance from `snapserver` when run via `launchctl`. Note that I did try `Adaptive` (which is recommended before using `Interactive`), but it did not perform any better than at the default priority. I also tested `snapclient`, and at least on my client machine (quad-core MBP), specifying `ProcessType` was not necessary.