### PR TITLE
librespot upstream changed the backend name from stdout to pipe

### DIFF
--- a/server/streamreader/spotifyStream.cpp
+++ b/server/streamreader/spotifyStream.cpp
@@ -42,7 +42,7 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	if (password.empty())
 		throw SnapException("missing parameter \"password\"");
 
-	params_ = "--name \"" + devicename + "\" --username \"" + username + "\" --password \"" + password + "\" --bitrate " + bitrate + " --backend stdout";
+	params_ = "--name \"" + devicename + "\" --username \"" + username + "\" --password \"" + password + "\" --bitrate " + bitrate + " --backend pipe";
 //	logO << "params: " << params << "\n";
 }
 


### PR DESCRIPTION
The stdout backend has been merged, but also been renamed in a later commit:
https://github.com/plietar/librespot/commit/9c3541c41b9f706153a696774be4eb7f8867fcd6

The documentation https://github.com/badaix/snapcast/blob/master/doc/player_setup.md#spotify also needs to be revised but I thought it's better to have that in a separate commit.