### PR TITLE
snapclient.service/snapserver.service:

### DIFF
--- a/client/debian/snapclient.service
+++ b/client/debian/snapclient.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Snapcast client
-After=network.target
+After=network-online.target sound.target
+Requires=network-online.target
 
 [Service]
 EnvironmentFile=-/etc/default/snapclient
 Type=forking
 ExecStart=/usr/sbin/snapclient $SNAPCLIENT_OPTS
 PIDFile=/var/run/snapclient.pid
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/server/debian/snapserver.service
+++ b/server/debian/snapserver.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Snapcast server
-After=network-online.target sound.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/server/debian/snapserver.service
+++ b/server/debian/snapserver.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Snapcast server
-After=network.target
+After=network-online.target sound.target
+Requires=network-online.target
 
 [Service]
 EnvironmentFile=-/etc/default/snapserver
 Type=forking
 ExecStart=/usr/sbin/snapserver $SNAPSERVER_OPTS
 PIDFile=/var/run/snapserver.pid
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Snapcast has to wait until complete network stack is up, in particular systemd-timesyncd is up and time is set. If not, there are drop outs after boot on the client.

This fixes https://github.com/badaix/snapcast/issues/138.

Signed-off-by: realglotzi <github@wagner-budenheim.de>