### PR TITLE
Prevent Overwriting of config file when reinstalling

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -111,7 +111,7 @@ endif
 installsystemd:
 	@echo using systemd; \
 	cp debian/$(BIN).service /lib/systemd/system/$(BIN).service; \
-	cp debian/$(BIN).default /etc/default/$(BIN); \
+	cp -n debian/$(BIN).default /etc/default/$(BIN); \
 	systemctl daemon-reload; \
 	systemctl enable $(BIN); \
 	systemctl start $(BIN); \
@@ -119,7 +119,7 @@ installsystemd:
 installsysv:
 	@echo using sysv; \
 	cp debian/$(BIN).init /etc/init.d/$(BIN); \
-	cp debian/$(BIN).default /etc/default/$(BIN); \
+	cp -n debian/$(BIN).default /etc/default/$(BIN); \
 	update-rc.d $(BIN) defaults; \
 	/etc/init.d/$(BIN) start; \
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -117,7 +117,7 @@ endif
 installsystemd:
 	@echo using systemd; \
 	cp debian/$(BIN).service /lib/systemd/system/$(BIN).service; \
-	cp debian/$(BIN).default /etc/default/$(BIN); \
+	cp -n debian/$(BIN).default /etc/default/$(BIN); \
 	systemctl daemon-reload; \
 	systemctl enable $(BIN); \
 	systemctl start $(BIN); \
@@ -125,7 +125,7 @@ installsystemd:
 installsysv:
 	@echo using sysv; \
 	cp debian/$(BIN).init /etc/init.d/$(BIN); \
-	cp debian/$(BIN).default /etc/default/$(BIN); \
+	cp -n debian/$(BIN).default /etc/default/$(BIN); \
 	update-rc.d $(BIN) defaults; \
 	/etc/init.d/$(BIN) start; \
 


### PR DESCRIPTION
As /etc/default/snapserver and /etc/default/snapclient include user configuration, make install should not overwrite them but just copy the templates there if the files dont exist yet. 