### PR TITLE
Make Librespot Credentials Optional

### DIFF
--- a/server/streamreader/spotifyStream.cpp
+++ b/server/streamreader/spotifyStream.cpp
@@ -37,12 +37,13 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	string bitrate = uri_.getQuery("bitrate", "320");
 	string devicename = uri_.getQuery("devicename", "Snapcast");
 
-	if (username.empty())
-		throw SnapException("missing parameter \"username\"");
-	if (password.empty())
-		throw SnapException("missing parameter \"password\"");
+	if (username.empty() != password.empty())
+		throw SnapException("missing parameter \"username\" or \"password\" (must provide both, or neither)");
 
-	params_ = "--name \"" + devicename + "\" --username \"" + username + "\" --password \"" + password + "\" --bitrate " + bitrate + " --backend pipe";
+	params_ = "--name \"" + devicename + "\"";
+	if (!username.empty() && !password.empty())
+		params_ += " --username \"" + username + "\" --password \"" + password + "\"";
+	params_ += " --bitrate " + bitrate + " --backend pipe";
 //	logO << "params: " << params << "\n";
 }
 


### PR DESCRIPTION
librespot does not require credentials in order to work.

from [the README](https://github.com/plietar/librespot#discovery-mode): 

> librespot can be run in discovery mode, in which case no password is required at startup. For that, simply omit the --username argument.

This PR allows both `username` and `password` to be omitted. If one is provided and the other is not, an error is thrown.