### PR TITLE
Fixing a re-sync issue on macOS by reworking CoreAudioPlayer

### DIFF
--- a/client/player/coreAudioPlayer.h
+++ b/client/player/coreAudioPlayer.h
@@ -44,12 +44,15 @@ public:
 
 protected:
 	virtual void worker();
+	void initAudioQueue();
+	void uninitAudioQueue(AudioQueueRef queue);
 
 	AudioQueueTimelineRef timeLine_;
 	size_t ms_;
 	size_t frames_;
 	size_t buff_size_;
 	std::shared_ptr<Stream> pubStream_;
+	long lastChunkTick;
 };
 
 


### PR DESCRIPTION
Now, similar to the AlsaPlayer, after 5 seconds of silence (no chunks received) the CoreAudio AudioQueue is destroyed. Once audio is resumed (i.e. a chunk is received) the AudioQueue is re-created.

Thanks for snapcast!