### PR TITLE
Use "which" instead of "whereis" to find the streaming executable

### DIFF
--- a/server/streamreader/processStream.cpp
+++ b/server/streamreader/processStream.cpp
@@ -45,7 +45,7 @@ ProcessStream::~ProcessStream()
 }
 
 
-bool ProcessStream::fileExists(const std::string& filename) 
+bool ProcessStream::fileExists(const std::string& filename)
 {
 	struct stat buffer;
 	return (stat(filename.c_str(), &buffer) == 0);
@@ -62,14 +62,10 @@ std::string ProcessStream::findExe(const std::string& filename)
 	if (exe.find("/") != string::npos)
 		exe = exe.substr(exe.find_last_of("/") + 1);
 
-	/// check with "whereis"
-	string whereis = execGetOutput("whereis " + exe);
-	if (whereis.find(":") != std::string::npos)
-	{
-		whereis = trim_copy(whereis.substr(whereis.find(":") + 1));
-		if (!whereis.empty())
-			return whereis;
-	}
+	/// check with "which"
+	string which = execGetOutput("which " + exe);
+	if (!which.empty())
+		return which;
 
 	/// check in the same path as this binary
 	char buff[PATH_MAX];


### PR DESCRIPTION
snapserver currently uses `whereis` in order to locate binaries. I believe `which` to be a better fit for its purposes:

1. The output of `whereis` is complex, and not easily parseable - it includes the binary name, the path to the binary, and potentially other files. I think this was the issue in #185 (notice that [the output of `whereis`](https://github.com/badaix/snapcast/issues/185#issuecomment-279528917) lists a `.conf` file first, instead of the binary as snapserver expects). `which`, on the other hand, simply outputs the full path to the file, if one is found.
    ```
    tommy@rpi:~ $ whereis ls
    ls: /bin/ls /usr/share/man/man1/ls.1.gz
    tommy@rpi:~ $ which ls
    /bin/ls
    ```
1. In some (many?) implementations of `whereis`, only "standard Linux places" are searched, whereas `which` searches the user's `PATH`. I think users are more likely to understand (and to place binaries in) their `PATH` than the "standard Linux places".

Refs:
* https://linux.die.net/man/1/whereis
* https://linux.die.net/man/1/which

I have only tested this on macOS, though I've verified that the `which` command works the same on Linux.