### PR TITLE
Allow building server and client without Ogg/FLAC support

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -25,20 +25,20 @@ ifeq ($(TARGET), ANDROID)
 
 CXX       = $(NDK_DIR)/bin/arm-linux-androideabi-g++
 STRIP     = $(NDK_DIR)/bin/arm-linux-androideabi-strip
-CXXFLAGS += -pthread -DANDROID -DNO_CPP11_STRING -fPIC -DHAS_TREMOR -DHAS_OPENSL -I$(NDK_DIR)/include
+CXXFLAGS += -pthread -DANDROID -DNO_CPP11_STRING -fPIC -DHAS_TREMOR -DHAS_FLAC -DHAS_OPENSL -I$(NDK_DIR)/include
 LDFLAGS   = -L$(NDK_DIR)/lib -pie -lvorbisidec -logg -lFLAC -lOpenSLES 
 OBJ      += player/openslPlayer.o 
 
 else ifeq ($(TARGET), OPENWRT)
 
 STRIP     = echo
-CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
+CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_FLAC -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
 LDFLAGS   = -lasound -lvorbisidec -logg -lFLAC -lavahi-client -lavahi-common -latomic
 OBJ      += player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 else ifeq ($(TARGET), BUILDROOT)
 
-CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
+CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_FLAC -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
 LDFLAGS  += -lasound -lvorbisidec -logg -lFLAC -lavahi-client -lavahi-common -latomic
 OBJ      += player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
@@ -46,7 +46,7 @@ else ifeq ($(TARGET), MACOS)
 
 CXX       = g++
 STRIP     = strip
-CXXFLAGS += -DHAS_OGG -DHAS_COREAUDIO -DFREEBSD -DMACOS -DHAS_BONJOUR -DHAS_DAEMON -I/usr/local/include -Wno-unused-local-typedef -Wno-deprecated
+CXXFLAGS += -DHAS_OGG -DHAS_FLAC -DHAS_COREAUDIO -DFREEBSD -DMACOS -DHAS_BONJOUR -DHAS_DAEMON -I/usr/local/include -Wno-unused-local-typedef -Wno-deprecated
 LDFLAGS   = -logg -lvorbis -lFLAC -L/usr/local/lib -framework AudioToolbox -framework CoreFoundation
 OBJ      += player/coreAudioPlayer.o browseZeroConf/browseBonjour.o
 
@@ -54,7 +54,7 @@ else
 
 CXX       = g++
 STRIP     = strip
-CXXFLAGS += -pthread -DHAS_OGG -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
+CXXFLAGS += -pthread -DHAS_OGG -DHAS_FLAC -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
 LDFLAGS   = -lrt -lasound -logg -lvorbis -lFLAC -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
 OBJ      += player/alsaPlayer.o browseZeroConf/browseAvahi.o
 

--- a/client/controller.cpp
+++ b/client/controller.cpp
@@ -20,11 +20,13 @@
 #include <string>
 #include <memory>
 #include "controller.h"
+#include "decoder/pcmDecoder.h"
 #if defined(HAS_OGG) || defined(HAS_TREMOR)
 #include "decoder/oggDecoder.h"
 #endif
-#include "decoder/pcmDecoder.h"
+#if defined(HAS_FLAC)
 #include "decoder/flacDecoder.h"
+#endif
 #include "timeProvider.h"
 #include "message/time.h"
 #include "message/hello.h"
@@ -109,8 +111,10 @@ void Controller::onMessageReceived(ClientConnection* connection, const msg::Base
 		else if (headerChunk_->codec == "ogg")
 			decoder_.reset(new OggDecoder());
 #endif
+#if defined(HAS_FLAC)
 		else if (headerChunk_->codec == "flac")
 			decoder_.reset(new FlacDecoder());
+#endif
 		else
 			throw SnapException("codec not supported: \"" + headerChunk_->codec + "\"");
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -13,7 +13,7 @@ else
   TARGET_DIR ?= /usr
 endif
 
-CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DHAS_OGG -DHAS_VORBIS -DHAS_VORBIS_ENC -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/jsonrpcpp/lib -I../externals
+CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DHAS_OGG -DHAS_VORBIS -DHAS_VORBIS_ENC -DHAS_FLAC -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/jsonrpcpp/lib -I../externals
 LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC
 OBJ       = snapServer.o config.o controlServer.o controlSession.o streamServer.o streamSession.o streamreader/streamUri.o streamreader/streamManager.o streamreader/pcmStream.o streamreader/pipeStream.o streamreader/fileStream.o streamreader/processStream.o streamreader/airplayStream.o streamreader/spotifyStream.o streamreader/watchdog.o encoder/encoderFactory.o encoder/flacEncoder.o encoder/pcmEncoder.o encoder/oggEncoder.o ../common/log.o ../common/sampleFormat.o ../message/pcmChunk.o ../externals/jsonrpcpp/lib/jsonrp.o
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -13,7 +13,7 @@ else
   TARGET_DIR ?= /usr
 endif
 
-CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/jsonrpcpp/lib -I../externals
+CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DHAS_OGG -DHAS_VORBIS -DHAS_VORBIS_ENC -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/jsonrpcpp/lib -I../externals
 LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC
 OBJ       = snapServer.o config.o controlServer.o controlSession.o streamServer.o streamSession.o streamreader/streamUri.o streamreader/streamManager.o streamreader/pcmStream.o streamreader/pipeStream.o streamreader/fileStream.o streamreader/processStream.o streamreader/airplayStream.o streamreader/spotifyStream.o streamreader/watchdog.o encoder/encoderFactory.o encoder/flacEncoder.o encoder/pcmEncoder.o encoder/oggEncoder.o ../common/log.o ../common/sampleFormat.o ../message/pcmChunk.o ../externals/jsonrpcpp/lib/jsonrp.o
 

--- a/server/encoder/encoderFactory.cpp
+++ b/server/encoder/encoderFactory.cpp
@@ -18,7 +18,9 @@
 
 #include "encoderFactory.h"
 #include "pcmEncoder.h"
+#if defined(HAS_OGG) && defined(HAS_VORBIS) && defined(HAS_VORBIS_ENC)
 #include "oggEncoder.h"
+#endif
 #include "flacEncoder.h"
 #include "common/utils.h"
 #include "common/snapException.h"
@@ -38,10 +40,12 @@ Encoder* EncoderFactory::createEncoder(const std::string& codecSettings) const
 		codecOptions = trim_copy(codec.substr(codec.find(":") + 1));
 		codec = trim_copy(codec.substr(0, codec.find(":")));
 	}
-	if (codec == "ogg")
+    if (codec == "pcm")
+        encoder = new PcmEncoder(codecOptions);
+#if defined(HAS_OGG) && defined(HAS_VORBIS) && defined(HAS_VORBIS_ENC)
+    else if (codec == "ogg")
 		encoder = new OggEncoder(codecOptions);
-	else if (codec == "pcm")
-		encoder = new PcmEncoder(codecOptions);
+#endif
 	else if (codec == "flac")
 		encoder = new FlacEncoder(codecOptions);
 	else

--- a/server/encoder/encoderFactory.cpp
+++ b/server/encoder/encoderFactory.cpp
@@ -21,7 +21,9 @@
 #if defined(HAS_OGG) && defined(HAS_VORBIS) && defined(HAS_VORBIS_ENC)
 #include "oggEncoder.h"
 #endif
+#if defined(HAS_FLAC)
 #include "flacEncoder.h"
+#endif
 #include "common/utils.h"
 #include "common/snapException.h"
 #include "common/log.h"
@@ -46,8 +48,10 @@ Encoder* EncoderFactory::createEncoder(const std::string& codecSettings) const
     else if (codec == "ogg")
 		encoder = new OggEncoder(codecOptions);
 #endif
+#if defined(FLAC)
 	else if (codec == "flac")
 		encoder = new FlacEncoder(codecOptions);
+#endif
 	else
 	{
 		throw SnapException("unknown codec: " + codec);


### PR DESCRIPTION
Allows building a pure PCM-only, Ogg- and FLAC-less snapclient and snapserver:

```
# readelf -d ./bin/snapserver | grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libjsonrpcpp.so]
 0x00000001 (NEEDED)                     Shared library: [libavahi-common.so.3]
 0x00000001 (NEEDED)                     Shared library: [libavahi-client.so.3]
 0x00000001 (NEEDED)                     Shared library: [libstdc++.so.6]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so]
```

Note, the current Makefile will always build the snapserver **with** an Ogg decoder.