### PR TITLE
Allow to use PCM devices which does not have a hint section

### DIFF
--- a/client/player/pcmDevice.h
+++ b/client/player/pcmDevice.h
@@ -24,7 +24,7 @@
 
 struct PcmDevice
 {
-	PcmDevice() : idx(-1){};
+	PcmDevice() : idx(-1), name("default") {};
 	int idx;
 	std::string name;
 	std::string description;

--- a/client/snapClient.cpp
+++ b/client/snapClient.cpp
@@ -40,30 +40,6 @@ using namespace popl;
 
 volatile sig_atomic_t g_terminated = false;
 
-PcmDevice getPcmDevice(const std::string& soundcard)
-{
-#ifdef HAS_ALSA
-	vector<PcmDevice> pcmDevices = AlsaPlayer::pcm_list();
-
-	try
-	{
-		int soundcardIdx = cpt::stoi(soundcard);
-		for (auto dev: pcmDevices)
-			if (dev.idx == soundcardIdx)
-				return dev;
-	}
-	catch(...)
-	{
-	}
-
-	for (auto dev: pcmDevices)
-		if (dev.name.find(soundcard) != string::npos)
-			return dev;
-#endif
-	PcmDevice pcmDevice;
-	return pcmDevice;
-}
-
 
 int main (int argc, char **argv)
 {
@@ -187,14 +163,10 @@ int main (int argc, char **argv)
 #endif
 		}
 
-		PcmDevice pcmDevice = getPcmDevice(soundcard);
-#if defined(HAS_ALSA)
-		if (pcmDevice.idx == -1)
-		{
-			cout << "soundcard \"" << soundcard << "\" not found\n";
-//			exit(EXIT_FAILURE);
-		}
-#endif
+		PcmDevice pcmDevice;
+		pcmDevice.idx = 1;
+		if (soundcardValue.isSet())
+			pcmDevice.name = soundcard;
 
 		if (host.empty())
 		{


### PR DESCRIPTION
`pcm_list()` only lists PCM devices which have a name hint section. Most ALSA configurations using [PCM plugins](http://www.alsa-project.org/alsa-doc/alsa-lib/pcm_plugins.html) does not define a name hint by default.

In order to use such PCM devices do not use `pcm_list()`, but simply use the soundcard string passed by the `-s` option to set the PCM device name.

Fixes: #215