### PR TITLE
Add onstart/onstop params to spotify

### DIFF
--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -133,7 +133,7 @@ Snapserver supports [shairport-sync](https://github.com/mikebrady/shairport-sync
 ### Spotify
 Snapserver supports [librespot](https://github.com/plietar/librespot) with `pipe` backend.
  1. Build and copy the `librespot` binary somewhere to your `PATH`, e.g. `/usr/local/bin/`
- 2. Configure snapserver with `-s "spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320]"`
+ 2. Configure snapserver with `-s "spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&onstart=/usr/bin/logger -t Snapcast Starting spotify...][&onstop=/usr/bin/logger -t Snapcast Stopping spotify...]"`
    * Valid bitrates are 96, 160, 320
 
 

--- a/server/streamreader/spotifyStream.cpp
+++ b/server/streamreader/spotifyStream.cpp
@@ -36,6 +36,8 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	string password = uri_.getQuery("password", "");
 	string bitrate = uri_.getQuery("bitrate", "320");
 	string devicename = uri_.getQuery("devicename", "Snapcast");
+	string onstart = uri_.getQuery("onstart", "");
+	string onstop = uri_.getQuery("onstop", "");
 
 	if (username.empty() != password.empty())
 		throw SnapException("missing parameter \"username\" or \"password\" (must provide both, or neither)");
@@ -44,6 +46,10 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	if (!username.empty() && !password.empty())
 		params_ += " --username \"" + username + "\" --password \"" + password + "\"";
 	params_ += " --bitrate " + bitrate + " --backend pipe";
+	if (!onstart.empty())
+		params_ += " --onstart \"" + onstart + "\"";
+	if (!onstop.empty())
+		params_ += " --onstop \"" + onstop + "\"";
 //	logO << "params: " << params << "\n";
 }
 


### PR DESCRIPTION
The *onstart* and *onstop* options can be used to execute a program or script when playback begins or ends.