### PR TITLE
Fix Buildroot server compilation error

### DIFF
--- a/buildroot/package/snapcast/S99snapserver
+++ b/buildroot/package/snapcast/S99snapserver
@@ -1,14 +1,14 @@
 #! /bin/sh
 
 start() {
-	echo -n "Starting snapclient: "
-	start-stop-daemon -S -q -b -x snapclient
+	echo -n "Starting snapserver: "
+	start-stop-daemon -S -q -b -x snapserver
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 }
 
 stop() {
-	echo -n "Stopping snapclient: "
-	start-stop-daemon -K -q -x snapclient
+	echo -n "Stopping snapserver: "
+	start-stop-daemon -K -q -x snapserver
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 }
 

--- a/buildroot/package/snapcast/S99snapserver
+++ b/buildroot/package/snapcast/S99snapserver
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+start() {
+	echo -n "Starting snapclient: "
+	start-stop-daemon -S -q -b -x snapclient
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+stop() {
+	echo -n "Stopping snapclient: "
+	start-stop-daemon -K -q -x snapclient
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	restart
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?

--- a/buildroot/package/snapcast/snapcast.mk
+++ b/buildroot/package/snapcast/snapcast.mk
@@ -7,7 +7,7 @@
 SNAPCAST_VERSION = master
 SNAPCAST_SITE = https://github.com/badaix/snapcast
 SNAPCAST_SITE_METHOD = git
-SNAPCAST_DEPENDENCIES = libogg alsa-lib #libstdcpp libavahi-client libatomic libflac libvorbisidec
+SNAPCAST_DEPENDENCIES = libogg alsa-lib # libstdcpp libavahi-client libatomic libflac libvorbisidec
 SNAPCAST_LICENSE = GPLv3
 SNAPCAST_LICENSE_FILES = COPYING
 
@@ -21,9 +21,7 @@ define SNAPCAST_EXTRACT_CMDS
 endef
 
 define SNAPCAST_BUILD_CMDS
-	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) TARGET=BUILDROOT
-#	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/client TARGET=BUILDROOT
-#	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/server TARGET=BUILDROOT
+	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) TARGET=BUILDROOT #build server and client
 endef
 
 define SNAPCAST_INSTALL_TARGET_CMDS

--- a/buildroot/package/snapcast/snapcast.mk
+++ b/buildroot/package/snapcast/snapcast.mk
@@ -7,7 +7,7 @@
 SNAPCAST_VERSION = master
 SNAPCAST_SITE = https://github.com/badaix/snapcast
 SNAPCAST_SITE_METHOD = git
-SNAPCAST_DEPENDENCIES = libogg alsa-lib # libstdcpp libavahi-client libatomic libflac libvorbisidec
+SNAPCAST_DEPENDENCIES = libogg alsa-lib #libstdcpp libavahi-client libatomic libflac libvorbisidec
 SNAPCAST_LICENSE = GPLv3
 SNAPCAST_LICENSE_FILES = COPYING
 
@@ -21,12 +21,16 @@ define SNAPCAST_EXTRACT_CMDS
 endef
 
 define SNAPCAST_BUILD_CMDS
-	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/client TARGET=BUILDROOT
+	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) TARGET=BUILDROOT
+#	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/client TARGET=BUILDROOT
+#	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/server TARGET=BUILDROOT
 endef
 
 define SNAPCAST_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/client/snapclient $(TARGET_DIR)/usr/bin/snapclient
+	$(INSTALL) -m 0755 -D $(@D)/server/snapserver $(TARGET_DIR)/usr/bin/snapserver
 	$(INSTALL) -m 0755 -D $(SNAPCAST_PKGDIR)/S99snapclient $(TARGET_DIR)/etc/init.d/S99snapclient
+	$(INSTALL) -m 0755 -D $(SNAPCAST_PKGDIR)/S99snapserver $(TARGET_DIR)/etc/init.d/S99snapserver
 endef
 
 $(eval $(generic-package))

--- a/server/Makefile
+++ b/server/Makefile
@@ -36,6 +36,12 @@ CXXFLAGS += -DNO_CPP11_STRING -DHAS_AVAHI -DHAS_DAEMON -pthread
 LDFLAGS  += -lavahi-client -lavahi-common -latomic
 OBJ      += publishZeroConf/publishAvahi.o 
 
+else ifeq ($(TARGET), BUILDROOT)
+
+CXXFLAGS += -DHAS_AVAHI -DHAS_DAEMON -pthread
+LDFLAGS   = -lrt -lvorbis -lvorbisenc -logg -lFLAC -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
+OBJ      += publishZeroConf/publishAvahi.o 
+
 else ifeq ($(TARGET), FREEBSD)
 
 CXX       = g++


### PR DESCRIPTION
Building the snapcast server inside buildroot produced an error message.
By adding buildroot as a target inside the Makefile like in the Makefile in snapclient and removing the strip and CXX commands I was able to fix it.
I also added a simple startup script for the server.
Greetings Phil