### PR TITLE
Support connecting to an IPv6 host in snapclient

### DIFF
--- a/client/clientConnection.cpp
+++ b/client/clientConnection.cpp
@@ -70,7 +70,7 @@ std::string ClientConnection::getMacAddress() const
 void ClientConnection::start()
 {
 	tcp::resolver resolver(io_service_);
-	tcp::resolver::query query(tcp::v4(), host_, cpt::to_string(port_), asio::ip::resolver_query_base::numeric_service);
+	tcp::resolver::query query(host_, cpt::to_string(port_), asio::ip::resolver_query_base::numeric_service);
 	auto iterator = resolver.resolve(query);
 	logO << "Connecting\n";
 	socket_.reset(new tcp::socket(io_service_));


### PR DESCRIPTION
This just removes the limit to tcp::v4 only, and allows the client to resolve either an IPv4 or IPv6 address.

Tested with the server running on alpine linux within docker (which is how the server is managing to listen on IPv6 - through docker's bridging stuff), with both Ubuntu 16.04 and Android clients.