### PR TITLE
Support IPv6 in snapserver

### DIFF
--- a/server/controlServer.cpp
+++ b/server/controlServer.cpp
@@ -126,7 +126,14 @@ void ControlServer::handleAccept(socket_ptr socket)
 
 void ControlServer::start()
 {
-	acceptor_ = make_shared<tcp::acceptor>(*io_service_, tcp::endpoint(tcp::v4(), port_));
+	asio::ip::address address = asio::ip::address::from_string("::");
+	tcp::endpoint endpoint(address, port_);
+	acceptor_ = make_shared<tcp::acceptor>(*io_service_, endpoint);
+	if (endpoint.protocol() == tcp::v6())
+	{
+		error_code ec;
+		acceptor_->set_option(asio::ip::v6_only(false), ec);
+	}
 	startAccept();
 }
 

--- a/server/streamServer.cpp
+++ b/server/streamServer.cpp
@@ -615,7 +615,14 @@ void StreamServer::start()
 		}
 		streamManager_->start();
 
-		acceptor_ = make_shared<tcp::acceptor>(*io_service_, tcp::endpoint(tcp::v4(), settings_.port));
+		asio::ip::address address = asio::ip::address::from_string("::");
+		tcp::endpoint endpoint(address, settings_.port);
+		acceptor_ = make_shared<tcp::acceptor>(*io_service_, endpoint);
+		if (endpoint.protocol() == tcp::v6())
+		{
+			error_code ec;
+			acceptor_->set_option(asio::ip::v6_only(false), ec);
+		}
 		startAccept();
 	}
 	catch (const std::exception& e)


### PR DESCRIPTION
This commit allows snapserver to listen on IPv4 and/or IPv6 when available, to go along with #273.

I've followed the example given in a boostcon presentation on IPv6 best practices here: https://raw.githubusercontent.com/boostcon/2011_presentations/master/wed/IPv6.pdf and so it should support systems with dual stack, IPv4 only or IPv6 only.

This works well for me and accepts clients on both IPv4 & IPV6:

    $ ./snapserver 
    Settings file: /home/mike/.config/snapserver/server.json
    2017-09-26 16-00-50 [out] Adding service 'Snapcast'
    2017-09-26 16-00-50 [out] PcmStream sampleFormat: 48000:16:2
    2017-09-26 16-00-50 [out] PipeStream mode: create
    2017-09-26 16-00-50 [out] Stream: {"fragment":"","host":"","path":"/tmp/snapfifo","query":{"buffer_ms":"20","codec":"flac","name":"default","sampleformat":"48000:16:2"},"raw":"pipe:///tmp/snapfifo?name=default","scheme":"pipe"}
    2017-09-26 16-00-50 [err] (PipeStream) Exception: end of file
    2017-09-26 16-00-51 [out] Service 'Snapcast' successfully established.
    2017-09-26 16-00-54 [Notice] ControlServer::NewConnection: 2a04:5d00:70:64f1:bdf0:8419:e02b:4ef5
    2017-09-26 16-01-25 [Err] Exception in ControlSession::reader(): read_until: End of file
    2017-09-26 16-01-25 [Notice] ControlServer::NewConnection: ::ffff:10.64.10.107

I tried disabling IPv6 with

    sudo sh -c 'echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6' 

and snapserver still comes up and works correctly on IPv4.

Also it would be easy to add a command-line option to set the bind address now, if you want that?
