### PR TITLE
Add instructions to build Debian packages

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -74,6 +74,13 @@ Install Snapserver
 
 This will copy the server binary to `/usr/bin` and update init.d/systemd to start the server as a daemon.
 
+### Debian packages
+
+Debian packages can be made with
+
+    $ sudo apt-get install dh-systemd
+    $ fakeroot make -C server -f debian/rules binary
+    $ fakeroot make -C client -f debian/rules binary
 
 ## FreeBSD (Native)
 Install the build tools and required libs:  


### PR DESCRIPTION
Add a couple of lines of documentation on how to build Debian packages
using the already provided support.