### PR TITLE
Fixing compilation error on macOS, introduced by adding -latomic

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -31,7 +31,7 @@ endif
 
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/aixlog/include
-LDFLAGS   = -logg -lFLAC -latomic
+LDFLAGS   = -logg -lFLAC
 OBJ       = snapClient.o stream.o clientConnection.o timeProvider.o player/player.o decoder/pcmDecoder.o decoder/oggDecoder.o decoder/flacDecoder.o controller.o ../message/pcmChunk.o ../common/sampleFormat.o
 
 ifeq ($(ENDIAN), BIG)
@@ -50,13 +50,13 @@ else ifeq ($(TARGET), OPENWRT)
 
 STRIP     = echo
 CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common
+LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 else ifeq ($(TARGET), BUILDROOT)
 
 CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common
+LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 else ifeq ($(TARGET), MACOS)
@@ -72,7 +72,7 @@ else
 CXX       = g++
 STRIP     = strip
 CXXFLAGS += -pthread -DHAS_OGG -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
+LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -static-libgcc -static-libstdc++ -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 endif

--- a/server/Makefile
+++ b/server/Makefile
@@ -30,7 +30,7 @@ else
 endif
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/aixlog/include -I../externals/jsonrpcpp/lib -I../externals
-LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC -latomic
+LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC
 OBJ       = snapServer.o config.o controlServer.o controlSession.o streamServer.o streamSession.o streamreader/streamUri.o streamreader/streamManager.o streamreader/pcmStream.o streamreader/pipeStream.o streamreader/fileStream.o streamreader/processStream.o streamreader/airplayStream.o streamreader/spotifyStream.o streamreader/watchdog.o encoder/encoderFactory.o encoder/flacEncoder.o encoder/pcmEncoder.o encoder/oggEncoder.o ../common/sampleFormat.o ../message/pcmChunk.o ../externals/jsonrpcpp/lib/jsonrp.o
 
 
@@ -43,13 +43,13 @@ ifeq ($(TARGET), ANDROID)
 CXX       = $(NDK_DIR)/bin/arm-linux-androideabi-g++
 STRIP     = $(NDK_DIR)/bin/arm-linux-androideabi-strip
 CXXFLAGS += -pthread -DANDROID -DNO_CPP11_STRING -fPIC -I$(NDK_DIR)/include
-LDFLAGS  += -L$(NDK_DIR)/lib -pie -llog
+LDFLAGS  += -L$(NDK_DIR)/lib -pie -llog -latomic
 
 else ifeq ($(TARGET), OPENWRT)
 
 STRIP     = echo
 CXXFLAGS += -DNO_CPP11_STRING -DHAS_AVAHI -DHAS_DAEMON -pthread
-LDFLAGS  += -lavahi-client -lavahi-common
+LDFLAGS  += -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o publishZeroConf/publishAvahi.o 
 
 else ifeq ($(TARGET), FREEBSD)
@@ -57,7 +57,7 @@ else ifeq ($(TARGET), FREEBSD)
 CXX       = g++
 STRIP     = echo
 CXXFLAGS += -DNO_CPP11_STRING -DFREEBSD -DHAS_AVAHI -DHAS_DAEMON -pthread
-LDFLAGS  += -lrt -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
+LDFLAGS  += -lrt -lavahi-client -lavahi-common -static-libgcc -static-libstdc++ -latomic
 OBJ      += ../common/daemon.o publishZeroConf/publishAvahi.o 
 
 else ifeq ($(TARGET), MACOS)


### PR DESCRIPTION
Compiling with `-latomic` doesn't work on macOS - the following error is thrown:
```
ld: library not found for -latomic
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Since `-latomic` was made a common flag in 0bc1db8, I just moved it to each individual platform's `LDFLAGS` statement, as long as it inherited the common flags.