### PR TITLE
Play a configurable amount of silence before going idle

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -31,7 +31,7 @@ endif
 
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/aixlog/include
-LDFLAGS   = -logg -lFLAC -latomic
+LDFLAGS   = -logg -lFLAC
 OBJ       = snapClient.o stream.o clientConnection.o timeProvider.o player/player.o decoder/pcmDecoder.o decoder/oggDecoder.o decoder/flacDecoder.o controller.o ../message/pcmChunk.o ../common/sampleFormat.o
 
 ifeq ($(ENDIAN), BIG)
@@ -50,13 +50,13 @@ else ifeq ($(TARGET), OPENWRT)
 
 STRIP     = echo
 CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common
+LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 else ifeq ($(TARGET), BUILDROOT)
 
 CXXFLAGS += -pthread -DNO_CPP11_STRING -DHAS_TREMOR -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common
+LDFLAGS  += -lasound -lvorbisidec -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 else ifeq ($(TARGET), MACOS)
@@ -72,7 +72,7 @@ else
 CXX       = g++
 STRIP     = strip
 CXXFLAGS += -pthread -DHAS_OGG -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
-LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
+LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -static-libgcc -static-libstdc++ -latomic
 OBJ      += ../common/daemon.o player/alsaPlayer.o browseZeroConf/browseAvahi.o
 
 endif

--- a/server/Makefile
+++ b/server/Makefile
@@ -30,7 +30,7 @@ else
 endif
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wno-unused-function -O3 -DASIO_STANDALONE -DVERSION=\"$(VERSION)\" -I. -I.. -isystem ../externals/asio/asio/include -I../externals/popl/include -I../externals/aixlog/include -I../externals/jsonrpcpp/lib -I../externals
-LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC -latomic
+LDFLAGS   = -lvorbis -lvorbisenc -logg -lFLAC
 OBJ       = snapServer.o config.o controlServer.o controlSession.o streamServer.o streamSession.o streamreader/streamUri.o streamreader/streamManager.o streamreader/pcmStream.o streamreader/pipeStream.o streamreader/fileStream.o streamreader/processStream.o streamreader/airplayStream.o streamreader/spotifyStream.o streamreader/watchdog.o encoder/encoderFactory.o encoder/flacEncoder.o encoder/pcmEncoder.o encoder/oggEncoder.o ../common/sampleFormat.o ../message/pcmChunk.o ../externals/jsonrpcpp/lib/jsonrp.o
 
 
@@ -43,13 +43,13 @@ ifeq ($(TARGET), ANDROID)
 CXX       = $(NDK_DIR)/bin/arm-linux-androideabi-g++
 STRIP     = $(NDK_DIR)/bin/arm-linux-androideabi-strip
 CXXFLAGS += -pthread -DANDROID -DNO_CPP11_STRING -fPIC -I$(NDK_DIR)/include
-LDFLAGS  += -L$(NDK_DIR)/lib -pie -llog
+LDFLAGS  += -L$(NDK_DIR)/lib -pie -llog -latomic
 
 else ifeq ($(TARGET), OPENWRT)
 
 STRIP     = echo
 CXXFLAGS += -DNO_CPP11_STRING -DHAS_AVAHI -DHAS_DAEMON -pthread
-LDFLAGS  += -lavahi-client -lavahi-common
+LDFLAGS  += -lavahi-client -lavahi-common -latomic
 OBJ      += ../common/daemon.o publishZeroConf/publishAvahi.o 
 
 else ifeq ($(TARGET), FREEBSD)
@@ -57,7 +57,7 @@ else ifeq ($(TARGET), FREEBSD)
 CXX       = g++
 STRIP     = echo
 CXXFLAGS += -DNO_CPP11_STRING -DFREEBSD -DHAS_AVAHI -DHAS_DAEMON -pthread
-LDFLAGS  += -lrt -lavahi-client -lavahi-common -static-libgcc -static-libstdc++
+LDFLAGS  += -lrt -lavahi-client -lavahi-common -static-libgcc -static-libstdc++ -latomic
 OBJ      += ../common/daemon.o publishZeroConf/publishAvahi.o 
 
 else ifeq ($(TARGET), MACOS)

--- a/server/streamreader/pcmStream.cpp
+++ b/server/streamreader/pcmStream.cpp
@@ -50,6 +50,11 @@ PcmStream::PcmStream(PcmListener* pcmListener, const StreamUri& uri) :
 
  	if (uri_.query.find("buffer_ms") != uri_.query.end())
 		pcmReadMs_ = cpt::stoul(uri_.query["buffer_ms"]);
+
+	if (uri_.query.find("dryout_ms") != uri_.query.end())
+		dryoutMs_ = cpt::stoul(uri_.query["dryout_ms"]);
+	else
+		dryoutMs_ = 2000;
 }
 
 

--- a/server/streamreader/pcmStream.h
+++ b/server/streamreader/pcmStream.h
@@ -100,6 +100,7 @@ protected:
 	StreamUri uri_;
 	SampleFormat sampleFormat_;
 	size_t pcmReadMs_;
+	size_t dryoutMs_;
 	std::unique_ptr<Encoder> encoder_;
 	std::string name_;
 	ReaderState state_;

--- a/server/streamreader/pipeStream.cpp
+++ b/server/streamreader/pipeStream.cpp
@@ -73,7 +73,7 @@ void PipeStream::worker()
 		tvEncodedChunk_ = tvChunk;
 		long nextTick = chronos::getTickCount();
 		int idleFrames = 0;
-		int maxIdleFrames = sampleFormat_.rate*2;
+		int maxIdleFrames = sampleFormat_.rate*dryoutMs_/1000;
 		try
 		{
 			if (fd_ == -1)

--- a/server/streamreader/processStream.cpp
+++ b/server/streamreader/processStream.cpp
@@ -159,7 +159,7 @@ void ProcessStream::worker()
 		tvEncodedChunk_ = tvChunk;
 		long nextTick = chronos::getTickCount();
 		int idleFrames = 0;
-		int maxIdleFrames = sampleFormat_.rate*2;
+		int maxIdleFrames = sampleFormat_.rate*dryoutMs_/1000;
 		try
 		{
 			while (active_)


### PR DESCRIPTION
This adds the ability for the server to fill the buffer with some amount of silence (before going idle) when audio data dries up. This can help with e.g. librespot outputting nothing in between songs. More discussion in #205.

This PR includes #283 because without it, I can't get the macOS version to compile.