### PR TITLE
Introduce TravisCI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: cpp
+compiler:
+  - gcc
+matrix:
+  include:
+    # build on ubuntu
+    - os: linux
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - build-essential libasound2-dev libvorbisidec-dev libvorbis-dev libflac-dev alsa-utils libavahi-client-dev avahi-daemon
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    # build on osx
+    - os: osx
+      osx_image: xcode9.1
+      env:
+        - MATRIX_EVAL="brew update && brew install flac libvorbis"
+  allow_failures:
+    - os: osx
+before_install:
+    - eval "${MATRIX_EVAL}"
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then BUILD_PARAMS="TARGET=MACOS"          ; fi
+  - make $BUILD_PARAMS
+  - sudo make installclient $BUILD_PARAMS
+  - sudo make installserver $BUILD_PARAMS


### PR DESCRIPTION
This TravisCI file builds Snapcast client & server on Ubuntu and MacOS and also tests the make installserver / installclient command.
Here you can see the successful build job in Travis of my branch:
https://travis-ci.org/ThYpHo0n/snapcast/builds/289466984

I think this is a good base and we can extend it in the future to e.g. also package .deb files or test on even more systems.