### PR TITLE
Use cubic mapping for volume

### DIFF
--- a/client/player/player.cpp
+++ b/client/player/player.cpp
@@ -83,12 +83,12 @@ void Player::adjustVolume(char* buffer, size_t frames)
 }
 
 
-//http://stackoverflow.com/questions/1165026/what-algorithms-could-i-use-for-audio-volume-level
+//https://cgit.freedesktop.org/pulseaudio/pulseaudio/tree/src/pulse/volume.c#n260
+//http://www.robotplanet.dk/audio/audio_gui_design/
+//https://lists.linuxaudio.org/pipermail/linux-audio-dev/2009-May/thread.html#22198
 void Player::setVolume(double volume)
 {
-	double base = M_E;
-//	double base = 10.;
-	volume_ = (pow(base, volume)-1) / (base-1);
+	volume_ = volume*volume*volume;
 	LOG(DEBUG) << "setVolume: " << volume << " => " << volume_ << "\n";
 }
 


### PR DESCRIPTION
This change currently is clearly incorrect, as clients whith and without it do not work well together (their sliders behave differently).

For me the current volume mapping is unusable. I like to have as few independent volume sliders as possible, which means with the slider on 100% I will get the maximum volume I possibly will ever want to use. My usual listening level is around -20dB (i.e. 10% of the full amplitude), corresponding to a slider position around 16% with the old mapping. Using the new mapping the slider is nicely positioned around 46% and perfectly usable.

I am quite happy to simply patch my locally compiled snapcast clients for having a cubic mapping, but if you think this might be of broader interest I could help implement some better or more flexible method, e.g. doing the mapping on the server side.