### PR TITLE
Add volume parameter to Librespot integration

### DIFF
--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -133,7 +133,7 @@ Snapserver supports [shairport-sync](https://github.com/mikebrady/shairport-sync
 ### Spotify
 Snapserver supports [librespot](https://github.com/plietar/librespot) with `pipe` backend.
  1. Build and copy the `librespot` binary somewhere to your `PATH`, e.g. `/usr/local/bin/`
- 2. Configure snapserver with `-s "spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&onstart=<start command>][&onstop=<stop command>][&cache=<cache dir>]"`
+ 2. Configure snapserver with `-s "spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&onstart=<start command>][&onstop=<stop command>][&volume=<volume in percent>][&cache=<cache dir>]"`
    * Valid bitrates are 96, 160, 320
    * `start command` and `stop command` are executed by Librespot at start/stop
      * For example: `onstart=/usr/bin/logger -t Snapcast Starting spotify...`

--- a/server/streamreader/spotifyStream.cpp
+++ b/server/streamreader/spotifyStream.cpp
@@ -36,6 +36,7 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	string username = uri_.getQuery("username", "");
 	string password = uri_.getQuery("password", "");
 	string cache = uri_.getQuery("cache", "");
+	string volume = uri_.getQuery("volume", "");
 	string bitrate = uri_.getQuery("bitrate", "320");
 	string devicename = uri_.getQuery("devicename", "Snapcast");
 	string onstart = uri_.getQuery("onstart", "");
@@ -50,6 +51,8 @@ SpotifyStream::SpotifyStream(PcmListener* pcmListener, const StreamUri& uri) : P
 	params_ += " --bitrate " + bitrate + " --backend pipe";
 	if (!cache.empty())
 		params_ += " --cache \"" + cache + "\"";
+	if (!volume.empty())
+		params_ += " --initial-volume \"" + volume + "\"";
 	if (!onstart.empty())
 		params_ += " --onstart \"" + onstart + "\"";
 	if (!onstop.empty())

--- a/server/streamreader/spotifyStream.h
+++ b/server/streamreader/spotifyStream.h
@@ -28,7 +28,7 @@
  * Implements EncoderListener to get the encoded data.
  * Data is passed to the PcmListener
  * usage:
- *   snapserver -s "spotify:///librespot?name=Spotify&username=<my username>&password=<my password>[&devicename=Snapcast][&bitrate=320][&cache=<cache dir>]"
+ *   snapserver -s "spotify:///librespot?name=Spotify&username=<my username>&password=<my password>[&devicename=Snapcast][&bitrate=320][&volume=<volume in percent>][&cache=<cache dir>]"
  */
 class SpotifyStream : public ProcessStream, WatchdogListener
 {


### PR DESCRIPTION
The maintained Version of librespot from https://github.com/librespot-org/librespot/ has introduced an "initial-volume" parameter.

Thought it would be nice for Snapserver to support this.