### PR TITLE
Corrected version string to 0.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(snapcast LANGUAGES CXX VERSION 0.11.1)
+project(snapcast LANGUAGES CXX VERSION 0.13.0)
 set(PROJECT_DESCRIPTION "Multi-room client-server audio player")
 set(PROJECT_URL "https://github.com/badaix/snapcast")
 


### PR DESCRIPTION
I just compiled the new version 0.13.0 and wondered why it was anounced as 0.11.1. I found the reason in the file CMakeLists.txt