### PR TITLE
Make OpenWrt/LEDE build working on MIPS 24KEc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,12 @@ target_architecture(ARCH)
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips"
     OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "armeb"
     OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "powerpc")
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-    add_definitions("-DIS_BIG_ENDIAN")    
+    INCLUDE(TestBigEndian)
+    TEST_BIG_ENDIAN(BIGENDIAN)
+    IF(${BIGENDIAN})
+        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
+        add_definitions("-DIS_BIG_ENDIAN")    
+    ENDIF(${BIGENDIAN})
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,10 @@ target_architecture(ARCH)
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips"
     OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "armeb"
     OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "powerpc")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
     INCLUDE(TestBigEndian)
     TEST_BIG_ENDIAN(BIGENDIAN)
     IF(${BIGENDIAN})
-        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
         add_definitions("-DIS_BIG_ENDIAN")    
     ENDIF(${BIGENDIAN})
 endif()


### PR DESCRIPTION
tested with MediaTek MT7620A, GL-MT300A, CPU: MIPS 24KEc V5.0
