### PR TITLE
Fixes for FreeBSD 11

### DIFF
--- a/common/utils/string_utils.h
+++ b/common/utils/string_utils.h
@@ -19,11 +19,11 @@
 #ifndef STRING_UTILS_H
 #define STRING_UTILS_H
 
+#include <stdio.h>
 #include <algorithm>
 #include <string>
 #include <sstream>
 #include <vector>
-
 
 namespace utils
 {

--- a/server/controlServer.cpp
+++ b/server/controlServer.cpp
@@ -136,8 +136,9 @@ void ControlServer::handleAccept(socket_ptr socket)
 
 void ControlServer::start()
 {
-	asio::ip::address address = asio::ip::address::from_string("::");
-	tcp::endpoint endpoint(address, port_);
+        tcp::endpoint endpoint(asio::ip::tcp::v4(), port_);
+        LOG(DEBUG) << "Control Server : " << endpoint.address().to_string() << ":" << endpoint.port() << "\n";
+
 	try
 	{
 		acceptor_ = make_shared<tcp::acceptor>(*io_service_, endpoint);

--- a/server/streamServer.cpp
+++ b/server/streamServer.cpp
@@ -385,7 +385,7 @@ void StreamServer::ProcessRequest(const jsonrpcpp::request_ptr request, jsonrpcp
 		{
 			if (request->method.find("Stream.SetMeta") == 0)
 			{
-				/// Request:      {"id":4,"jsonrpc":"2.0","method":"Stream.SetMeta","params":{"stream_id":"Spotify",
+				/// Request:      {"id":4,"jsonrpc":"2.0","method":"Stream.SetMeta","params":{"id":"Spotify",
  				///                "meta": {"album": "some album", "artist": "some artist", "track": "some track"...}}}
 				///
 				/// Response:     {"id":4,"jsonrpc":"2.0","result":{"stream_id":"Spotify"}}
@@ -672,8 +672,8 @@ void StreamServer::start()
 		}
 		streamManager_->start();
 
-		asio::ip::address address = asio::ip::address::from_string("::");
-		tcp::endpoint endpoint(address, settings_.port);
+                tcp::endpoint endpoint(asio::ip::tcp::v4(), settings_.port);
+                LOG(DEBUG) << "Stream Server : " << endpoint.address().to_string() << ":" << endpoint.port() << "\n";
 		try
 		{
 			acceptor_ = make_shared<tcp::acceptor>(*io_service_, endpoint);

--- a/server/streamreader/airplayStream.cpp
+++ b/server/streamreader/airplayStream.cpp
@@ -45,7 +45,7 @@ AirplayStream::AirplayStream(PcmListener* pcmListener, const StreamUri& uri) : P
 {
 	logStderr_ = true;
 
-	pipePath_ = "/tmp/shairmeta." + to_string(getpid());
+        pipePath_ = "/tmp/shairmeta." + cpt::to_string(getpid());
 	//cout << "Pipe [" << pipePath_ << "]\n";
 
 	// XXX: Check if pipe exists, delete or throw error


### PR DESCRIPTION
Couple of minor fixes to compilation on FreeBSD which resolve Issue #374 I raised earlier

And change to initialisation of listeners which addresses Issue #336.    Looks like this was caused by the listeners being set up using ip address '::' which on FreeBSD resulted on the only listening on localhost (Oddly I didn't even get a response on 127.0.0.1 when they were set up like this).  