### PR TITLE
Allow playback when server uses large buffer

### DIFF
--- a/client/controller.cpp
+++ b/client/controller.cpp
@@ -126,7 +126,7 @@ void Controller::onMessageReceived(ClientConnection* connection, const msg::Base
 		stream_->setBufferLen(serverSettings_->getBufferMs() - latency_);
 
 #ifdef HAS_ALSA
-		player_.reset(new AlsaPlayer(pcmDevice_, stream_));
+		player_.reset(new AlsaPlayer(pcmDevice_, stream_, serverSettings_->getBufferMs()));
 #elif HAS_OPENSL
 		player_.reset(new OpenslPlayer(pcmDevice_, stream_));
 #elif HAS_COREAUDIO

--- a/client/player/alsaPlayer.h
+++ b/client/player/alsaPlayer.h
@@ -30,7 +30,7 @@
 class AlsaPlayer : public Player
 {
 public:
-	AlsaPlayer(const PcmDevice& pcmDevice, std::shared_ptr<Stream> stream);
+	AlsaPlayer(const PcmDevice& pcmDevice, std::shared_ptr<Stream> stream, const int timeout);
 	virtual ~AlsaPlayer();
 
 	/// Set audio volume in range [0..1]
@@ -50,6 +50,7 @@ private:
 	snd_pcm_t* handle_;
 	snd_pcm_uframes_t frames_;
 	char *buff_;
+	int timeout_;
 };
 
 

--- a/client/stream.cpp
+++ b/client/stream.cpp
@@ -73,8 +73,6 @@ void Stream::clearChunks()
 
 void Stream::addChunk(msg::PcmChunk* chunk)
 {
-	while (chunks_.size() * chunk->duration<cs::msec>().count() > 10000)
-		chunks_.pop();
 	chunks_.push(shared_ptr<msg::PcmChunk>(chunk));
 //	LOG(DEBUG) << "new chunk: " << chunk->duration<cs::msec>().count() << ", Chunks: " << chunks_.size() << "\n";
 }
@@ -336,8 +334,8 @@ bool Stream::getPlayerChunk(void* outputBuffer, const cs::usec& outputBufferDacT
 
 		if (sleep_.count() != 0)
 		{
-			static int lastAge(0);
-			int msAge = cs::duration<cs::msec>(age);
+			static long long lastAge(0);
+			long long msAge = cs::duration<cs::msec>(age);
 			if (lastAge != msAge) 
 			{
 				lastAge = msAge;

--- a/server/streamServer.cpp
+++ b/server/streamServer.cpp
@@ -648,8 +648,8 @@ void StreamServer::handleAccept(socket_ptr socket)
 	try
 	{
 		struct timeval tv;
-		tv.tv_sec  = 5;
-		tv.tv_usec = 0;
+		tv.tv_sec  = settings_.bufferMs / 1000;
+		tv.tv_usec = settings_.bufferMs % 1000;
 		setsockopt(socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 		setsockopt(socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 

--- a/server/streamServer.cpp
+++ b/server/streamServer.cpp
@@ -654,7 +654,7 @@ void StreamServer::handleAccept(socket_ptr socket)
 		setsockopt(socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
 		/// experimental: turn on tcp::no_delay
-		socket->set_option(tcp::no_delay(true));
+		//socket->set_option(tcp::no_delay(true));
 
 		SLOG(NOTICE) << "StreamServer::NewConnection: " << socket->remote_endpoint().address().to_string() << endl;
 		shared_ptr<StreamSession> session = make_shared<StreamSession>(this, socket);


### PR DESCRIPTION
This Patch will adust tcp timeouts to cope with bufferMs and it will adjust rules for purging data from the stream. (let the client handle purging, the stream is just for transporting data)

This fixes #430 