### PR TITLE
Avoid Audio Dropouts due to Resync

### DIFF
--- a/server/streamreader/pipeStream.cpp
+++ b/server/streamreader/pipeStream.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 
 
-PipeStream::PipeStream(PcmListener* pcmListener, const StreamUri& uri) : PcmStream(pcmListener, uri), fd_(-1)
+PipeStream::PipeStream(PcmListener* pcmListener, const StreamUri& uri, const long bufferMs) : PcmStream(pcmListener, uri), fd_(-1), bufferMs_(bufferMs)
 {
 	umask(0);
 	string mode = uri_.getQuery("mode", "create");
@@ -61,8 +61,6 @@ PipeStream::~PipeStream()
 
 void PipeStream::worker()
 {
-	int bufferMs_= 15000; // TODO: do not hardcode this. this should correspond to the bufferMs for streamsession
-
 	timeval tvChunk;
 	std::unique_ptr<msg::PcmChunk> chunk(new msg::PcmChunk(sampleFormat_, pcmReadMs_));
 	string lastException = "";

--- a/server/streamreader/pipeStream.cpp
+++ b/server/streamreader/pipeStream.cpp
@@ -35,10 +35,12 @@ using namespace std;
 
 
 
-PipeStream::PipeStream(PcmListener* pcmListener, const StreamUri& uri, const long bufferMs) : PcmStream(pcmListener, uri), fd_(-1), bufferMs_(bufferMs)
+PipeStream::PipeStream(PcmListener* pcmListener, const StreamUri& uri) : PcmStream(pcmListener, uri), fd_(-1)
 {
 	umask(0);
 	string mode = uri_.getQuery("mode", "create");
+	string timeout = uri_.getQuery("timeout_ms", "create");
+	bufferMs_ = cpt::stoul(timeout);
 		
 	LOG(INFO) << "PipeStream mode: " << mode << "\n";
 	if ((mode != "read") && (mode != "create"))

--- a/server/streamreader/pipeStream.cpp
+++ b/server/streamreader/pipeStream.cpp
@@ -141,8 +141,8 @@ void PipeStream::worker()
 				if (data_in_this_cycle) {
 					encoder_->encode(chunk.get());
 					if (!active_) break;
-					chronos::addUs(tvChunk, pcmReadMs_ * 1000);
 				}
+				chronos::addUs(tvChunk, pcmReadMs_ * 1000);
 				lastException = "";
 			}
 		}

--- a/server/streamreader/pipeStream.h
+++ b/server/streamreader/pipeStream.h
@@ -33,12 +33,13 @@ class PipeStream : public PcmStream
 {
 public:
 	/// ctor. Encoded PCM data is passed to the PipeListener
-	PipeStream(PcmListener* pcmListener, const StreamUri& uri);
+	PipeStream(PcmListener* pcmListener, const StreamUri& uri, const long bufferMs);
 	virtual ~PipeStream();
 
 protected:
 	virtual void worker();
 	int fd_;
+	long bufferMs_;
 };
 
 

--- a/server/streamreader/pipeStream.h
+++ b/server/streamreader/pipeStream.h
@@ -33,7 +33,7 @@ class PipeStream : public PcmStream
 {
 public:
 	/// ctor. Encoded PCM data is passed to the PipeListener
-	PipeStream(PcmListener* pcmListener, const StreamUri& uri, const long bufferMs);
+	PipeStream(PcmListener* pcmListener, const StreamUri& uri);
 	virtual ~PipeStream();
 
 protected:

--- a/server/streamreader/streamManager.cpp
+++ b/server/streamreader/streamManager.cpp
@@ -58,7 +58,7 @@ PcmStreamPtr StreamManager::addStream(const std::string& uri)
 
 	if (streamUri.scheme == "pipe")
 	{
-		stream = make_shared<PipeStream>(pcmListener_, streamUri);
+		stream = make_shared<PipeStream>(pcmListener_, streamUri, readBufferMs_);
 	}
 	else if (streamUri.scheme == "file")
 	{

--- a/server/streamreader/streamManager.cpp
+++ b/server/streamreader/streamManager.cpp
@@ -49,6 +49,9 @@ PcmStreamPtr StreamManager::addStream(const std::string& uri)
 	if (streamUri.query.find("buffer_ms") == streamUri.query.end())
 		streamUri.query["buffer_ms"] = cpt::to_string(readBufferMs_);
 
+	if (streamUri.query.find("timeout_ms") == streamUri.query.end())
+		streamUri.query["timeout_ms"] = cpt::to_string(1000);
+
 //	LOG(DEBUG) << "\nURI: " << streamUri.uri << "\nscheme: " << streamUri.scheme << "\nhost: "
 //		<< streamUri.host << "\npath: " << streamUri.path << "\nfragment: " << streamUri.fragment << "\n";
 
@@ -58,7 +61,7 @@ PcmStreamPtr StreamManager::addStream(const std::string& uri)
 
 	if (streamUri.scheme == "pipe")
 	{
-		stream = make_shared<PipeStream>(pcmListener_, streamUri, readBufferMs_);
+		stream = make_shared<PipeStream>(pcmListener_, streamUri);
 	}
 	else if (streamUri.scheme == "file")
 	{

--- a/server/streamreader/streamManager.h
+++ b/server/streamreader/streamManager.h
@@ -27,6 +27,7 @@ private:
 	std::string sampleFormat_;
 	std::string codec_;
 	size_t readBufferMs_;
+	long timeout_;
 };
 
 


### PR DESCRIPTION
Using sleep inside pipestream causes a sliding clock. This results in data not being read from the input fifo and in turn causes audio dropouts for clients.

This PR introduces a mechanism that does not require sleep() and gets rid of the audio dropouts.

This fixes #433 