### PR TITLE
Fixes in Daemon priority and Dropouts in audio

### DIFF
--- a/server/debian/snapserver.default
+++ b/server/debian/snapserver.default
@@ -20,10 +20,14 @@ START_SNAPSERVER=true
 #   --streamBuffer arg (=20)            Default stream read buffer [ms]
 #   -b, --buffer arg (=1000)            Buffer [ms]
 #   --sendToMuted                       Send audio to muted clients
-#   -d, --daemon [=arg(=0)]             Daemonize
-#                                       optional process priority [-20..19]
 #   --user arg                          the user[:group] to run snapserver as when daemonized
+
 
 USER_OPTS="--user snapserver:snapserver"
 
 SNAPSERVER_OPTS=""
+
+
+# optional process priority [-20..19]
+#DAEMONIZE="-d-10"
+DAEMONIZE="-d"

--- a/server/debian/snapserver.init
+++ b/server/debian/snapserver.init
@@ -27,7 +27,7 @@ USER_OPTS="--user snapserver:snapserver"
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
-SNAPSERVER_OPTS="-d $USER_OPTS $SNAPSERVER_OPTS"
+SNAPSERVER_OPTS="$DAEMONIZE $USER_OPTS $SNAPSERVER_OPTS"
 
 if [ "$START_SNAPSERVER" != "true" ] ; then
   exit 0

--- a/server/debian/snapserver.service
+++ b/server/debian/snapserver.service
@@ -6,7 +6,7 @@ Requires=network-online.target
 [Service]
 EnvironmentFile=-/etc/default/snapserver
 Type=forking
-ExecStart=/usr/bin/snapserver -d $USER_OPTS $SNAPSERVER_OPTS
+ExecStart=/usr/bin/snapserver $DAEMONIZE $USER_OPTS $SNAPSERVER_OPTS
 PIDFile=/var/run/snapserver/pid
 Restart=always
 

--- a/server/snapServer.cpp
+++ b/server/snapServer.cpp
@@ -170,15 +170,17 @@ int main(int argc, char* argv[])
 					group = user_group[1];
 			}
 
-			Config::instance().init("/var/lib/snapserver", user, group);
-			daemon.reset(new Daemon(user, group, "/var/run/snapserver/pid"));
-			daemon->daemonize();
+			// Update process priority if set on commandline
 			if (processPriority < -20)
 				processPriority = -20;
 			else if (processPriority > 19)
 				processPriority = 19;
 			if (processPriority != 0)
 				setpriority(PRIO_PROCESS, 0, processPriority);
+
+			Config::instance().init("/var/lib/snapserver", user, group);
+			daemon.reset(new Daemon(user, group, "/var/run/snapserver/pid"));
+			daemon->daemonize();
 			SLOG(NOTICE) << "daemon started" << std::endl;
 		}
 		else

--- a/server/streamreader/pcmStream.cpp
+++ b/server/streamreader/pcmStream.cpp
@@ -56,6 +56,12 @@ PcmStream::PcmStream(PcmListener* pcmListener, const StreamUri& uri) :
 	else
 		dryoutMs_ = 2000;
 
+	// before_dryout_ms needs to be smaller than the Client Buffer. Leaving this to the user for now.
+	if (uri_.query.find("before_dryout_ms") != uri_.query.end())
+		beforeDryoutMs_ = cpt::stoul(uri_.query["before_dryout_ms"]);
+	else
+		beforeDryoutMs_ = 0;
+
 	//meta_.reset(new msg::StreamTags());
 	//meta_->msg["stream"] = name_;
 	setMeta(json());

--- a/server/streamreader/pcmStream.h
+++ b/server/streamreader/pcmStream.h
@@ -106,6 +106,7 @@ protected:
 	SampleFormat sampleFormat_;
 	size_t pcmReadMs_;
 	size_t dryoutMs_;
+	size_t beforeDryoutMs_;
 	std::unique_ptr<Encoder> encoder_;
 	std::string name_;
 	ReaderState state_;


### PR DESCRIPTION
Dear maintainer,

I have two commits for you to review and (hopefully) include into the main Snapcast repository.

The first commit: Because it was (in practice) not possible to set process priority for the daemon.

The second commit: I did a lot of debugging on dropouts. There were a few issues. First of all was the fact the when a small problem arose, the server immediately went into Idle mode AND immediately did a ReSync. This was not good for audio quality unless working in a perfect environment on a perfect server.

I fixed these things by:
- Making a configurable cool-down period (before_dryout_ms) before silence gets inserted into the buffer. This is meant for slow servers where the input pipe misses a few beats from time to time. Default value is zero at the moment. I use 1500 ms, when the Client Buffer is 3000 ms.
- Making sure the buffer gets refilled fast from the pipe when data is available, until we have enough buffer again.
- Having a back-off time for the ReSync

Thank you for your cool software!
