### PR TITLE
Add "snapcastjsonrpc" as mdns name

### DIFF
--- a/server/snapServer.cpp
+++ b/server/snapServer.cpp
@@ -190,7 +190,11 @@ int main(int argc, char* argv[])
 
 #if defined(HAS_AVAHI) || defined(HAS_BONJOUR)
 		PublishZeroConf publishZeroConfg("Snapcast");
-		publishZeroConfg.publish({mDNSService("_snapcast._tcp", settings.port), mDNSService("_snapcast-jsonrpc._tcp", settings.controlPort)});
+		publishZeroConfg.publish({
+			mDNSService("_snapcast._tcp", settings.port),
+			mDNSService("_snapcast-jsonrpc._tcp", settings.controlPort),
+			mDNSService("_snapcastjsonrpc._tcp", settings.controlPort)
+		});
 #endif
 
 		if (settings.bufferMs < 400)


### PR DESCRIPTION
Service name is one byte too long. Added an alternative version
without removing the previous one for backwards compatibility.

Fixes #243