### PR TITLE
Added a new web interface to the list in the Readme.md file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For a webinterface in python, see [snapcastr](https://github.com/xkonni/snapcast
 
 Another webinterface running on any device, see [snapcast-websockets-ui](https://github.com/derglaus/snapcast-websockets-ui), running entirely in the browser, needs [websockify](https://github.com/novnc/websockify). No configuration needed, features almost all functions, still needs some tuning for the optics.
 
-A webinterface called [HydraPlay](https://github.com/mariolukas/HydraPlay) which integrates Snapcast and multiple Mopidy instances. It is JavaScript based and uses Angular 7. A Snapcast websocket proxy server is needed to connect Snapcast to the UI over web sockets.
+A webinterface called [HydraPlay](https://github.com/mariolukas/HydraPlay) which integrates Snapcast and multiple Mopidy instances. It is JavaScript based and uses Angular 7. A Snapcast websocket proxy server is needed to connect Snapcast to HydraPlay over web sockets.
 
 Setup of audio players/server
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ For a webinterface in python, see [snapcastr](https://github.com/xkonni/snapcast
 
 Another webinterface running on any device, see [snapcast-websockets-ui](https://github.com/derglaus/snapcast-websockets-ui), running entirely in the browser, needs [websockify](https://github.com/novnc/websockify). No configuration needed, features almost all functions, still needs some tuning for the optics.
 
+A webinterface called [HydraPlay](https://github.com/mariolukas/HydraPlay) which integrates Snapcast and multiple Mopidy instances. It is JavaScript based and uses Angular 7. A Snapcast websocket proxy server is needed to connect Snapcast to the UI over web sockets.
+
 Setup of audio players/server
 -----------------------------
 Snapcast can be used with a number of different audio players and servers, and so it can be integrated into your favorite audio-player solution and make it synced-multiroom capable.


### PR DESCRIPTION
I created a player, called HydraPlay. The Player is able to manage a Snapcast setup with multiple Mopidy sources. The interface is written in JavaScript in Angular 7. A web socket proxy to Snapcast is needed for communication between Hydraplay and Snapcast. I have written a small python server for this job, but i think i will switchover to websockify.