### PR TITLE
Added boost_system library to link client.

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -35,7 +35,7 @@ DEBUG=-O3
 
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wextra -Wpedantic -Wno-unused-function $(DEBUG) -DHAS_FLAC -DHAS_OGG -DVERSION=\"$(VERSION)\" -I. -I.. -I../common
-LDFLAGS   = $(ADD_LDFLAGS) -logg -lFLAC
+LDFLAGS   = $(ADD_LDFLAGS) -logg -lFLAC -lboost_system
 OBJ       = snapclient.o stream.o client_connection.o time_provider.o player/player.o decoder/pcm_decoder.o decoder/ogg_decoder.o decoder/flac_decoder.o controller.o ../common/sample_format.o
 
 


### PR DESCRIPTION
Had problems compiling the client code. As far as I can see it was only missing the boost_system library in the linking phase. Works for me after this change.

Regards,

Mark