### PR TITLE
Make sure to pick up LDFLAGS from environment.

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -35,7 +35,7 @@ DEBUG=-O3
 
 
 CXXFLAGS += $(ADD_CFLAGS) -std=c++0x -Wall -Wextra -Wpedantic -Wno-unused-function $(DEBUG) -DBOOST_ERROR_CODE_HEADER_ONLY -DHAS_FLAC -DHAS_OGG -DVERSION=\"$(VERSION)\" -I. -I.. -I../common
-LDFLAGS   = $(ADD_LDFLAGS) -logg -lFLAC
+LDFLAGS  += $(ADD_LDFLAGS) -logg -lFLAC
 OBJ       = snapclient.o stream.o client_connection.o time_provider.o player/player.o decoder/pcm_decoder.o decoder/ogg_decoder.o decoder/flac_decoder.o controller.o ../common/sample_format.o
 
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -36,7 +36,7 @@ SANITIZE=
 #-fsanitize=thread
 
 CXXFLAGS += $(ADD_CFLAGS) $(SANITIZE) -std=c++14 -Wall -Wextra -Wpedantic -Wno-unused-function $(DEBUG) -DBOOST_ERROR_CODE_HEADER_ONLY -DHAS_FLAC -DHAS_OGG -DHAS_VORBIS -DHAS_VORBIS_ENC -DVERSION=\"$(VERSION)\" -I. -I.. -I../common
-LDFLAGS   = $(ADD_LDFLAGS) $(SANITIZE) -lvorbis -lvorbisenc -logg -lFLAC 
+LDFLAGS  += $(ADD_LDFLAGS) $(SANITIZE) -lvorbis -lvorbisenc -logg -lFLAC 
 OBJ       = snapserver.o config.o control_server.o control_session_tcp.o control_session_http.o stream_server.o stream_session.o streamreader/stream_uri.o streamreader/base64.o streamreader/stream_manager.o streamreader/pcm_stream.o streamreader/pipe_stream.o streamreader/file_stream.o streamreader/process_stream.o streamreader/airplay_stream.o streamreader/librespot_stream.o streamreader/watchdog.o encoder/encoder_factory.o encoder/flac_encoder.o encoder/pcm_encoder.o encoder/ogg_encoder.o ../common/sample_format.o
 
 ifneq (,$(TARGET))


### PR DESCRIPTION
Adapted the Makefiles for the client and server to make sure that
any LDFLAGS settings that exist in the environment are also picked up.
This brings it in line with the CXXFLAGS implementation which also
picks up settings from the environment.
This is needed because some distributions allow to set general compiler
and linker flags in a central configuration file.