### PR TITLE
Snapclient systemd service to after=network-online

### DIFF
--- a/debian/snapclient.service
+++ b/debian/snapclient.service
@@ -2,7 +2,7 @@
 Description=Snapcast client
 Documentation=man:snapclient(1)
 Wants=avahi-daemon.service
-After=network.target time-sync.target sound.target avahi-daemon.service
+After=network-online.target time-sync.target sound.target avahi-daemon.service
 
 [Service]
 EnvironmentFile=-/etc/default/snapclient


### PR DESCRIPTION
As the client for snapcast requires internet connection it makes more sense to use the target *network-online*, instead of just *network*, as *network* will be ready when the network stack is ready and not necessarily when there is an internet connection.