### PR TITLE
Overwrite sample format for airplay before ctor is called

### DIFF
--- a/server/streamreader/airplay_stream.cpp
+++ b/server/streamreader/airplay_stream.cpp
@@ -59,9 +59,6 @@ AirplayStream::AirplayStream(PcmListener* pcmListener, boost::asio::io_context& 
 
     // XXX: Check if pipe exists, delete or throw error
 
-    sampleFormat_ = SampleFormat("44100:16:2");
-    uri_.query["sampleformat"] = sampleFormat_.getFormat();
-
     port_ = cpt::stoul(uri_.getQuery("port", "5000"));
 
     string devicename = uri_.getQuery("devicename", "Snapcast");

--- a/server/streamreader/librespot_stream.cpp
+++ b/server/streamreader/librespot_stream.cpp
@@ -34,12 +34,6 @@ static constexpr auto LOG_TAG = "LibrespotStream";
 
 LibrespotStream::LibrespotStream(PcmListener* pcmListener, boost::asio::io_context& ioc, const StreamUri& uri) : ProcessStream(pcmListener, ioc, uri)
 {
-    sampleFormat_ = SampleFormat("44100:16:2");
-    uri_.query["sampleformat"] = sampleFormat_.getFormat();
-    // chunk is created in PcmStream ctor, using the (possibly wrongly) configured sample format
-    // we have to recreate it using spotify's native sample format
-    chunk_ = std::make_unique<msg::PcmChunk>(sampleFormat_, chunk_ms_);
-
     wd_timeout_sec_ = cpt::stoul(uri_.getQuery("wd_timeout", "7800")); ///< 130min
 
     string username = uri_.getQuery("username", "");

--- a/server/streamreader/stream_manager.cpp
+++ b/server/streamreader/stream_manager.cpp
@@ -75,10 +75,18 @@ PcmStreamPtr StreamManager::addStream(const std::string& uri)
     }
     else if ((streamUri.scheme == "spotify") || (streamUri.scheme == "librespot"))
     {
+        // Overwrite sample format here instead of inside the constructor, to make sure
+        // that all constructors of all parent classes also use the overwritten sample
+        // format.
+        streamUri.query[kUriSampleFormat] = "44100:16:2";
         stream = make_shared<LibrespotStream>(pcmListener_, ioc_, streamUri);
     }
     else if (streamUri.scheme == "airplay")
     {
+        // Overwrite sample format here instead of inside the constructor, to make sure
+        // that all constructors of all parent classes also use the overwritten sample
+        // format.
+        streamUri.query[kUriSampleFormat] = "44100:16:2";
         stream = make_shared<AirplayStream>(pcmListener_, ioc_, streamUri);
     }
     else if (streamUri.scheme == "tcp")


### PR DESCRIPTION
This fixes an issue with the airplay stream. The sample format was overwritten in the constructor, but (unlike in the librespot stream) the `chunk_` was not recreated. To avoid this oversight in the future, the sample format overwrite is moved into the stream manager for both airplay and librespot.