### PR TITLE
Add option to not kill all librespot instances

### DIFF
--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -151,11 +151,11 @@ Snapserver supports [shairport-sync](https://github.com/mikebrady/shairport-sync
 ### Spotify
 Snapserver supports [librespot](https://github.com/librespot-org/librespot) with the `pipe` backend.
  1. Build and copy the `librespot` binary somewhere to your `PATH`, e.g. `/usr/local/bin/`
- 2. Configure snapserver with `stream = spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&onstart=<start command>][&onstop=<stop command>][&volume=<volume in percent>][&cache=<cache dir>]`
+ 2. Configure snapserver with `stream = spotify:///librespot?name=Spotify[&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&onstart=<start command>][&onstop=<stop command>][&volume=<volume in percent>][&cache=<cache dir>][&killall=true]`
    * Valid bitrates are 96, 160, 320
    * `start command` and `stop command` are executed by Librespot at start/stop
      * For example: `onstart=/usr/bin/logger -t Snapcast Starting spotify...`
-
+   * If `killall` is `true` (default), all running instances of Librespot will be killed. This MUST be disabled on all spotify streams by setting it to `false` if you want to use multiple spotify streams.
 
 ### Process
 Snapserver can start any process and read PCM data from the stdout of the process: 

--- a/server/streamreader/librespot_stream.cpp
+++ b/server/streamreader/librespot_stream.cpp
@@ -44,6 +44,7 @@ LibrespotStream::LibrespotStream(PcmListener* pcmListener, boost::asio::io_conte
     string devicename = uri_.getQuery("devicename", "Snapcast");
     string onevent = uri_.getQuery("onevent", "");
     bool normalize = (uri_.getQuery("normalize", "false") == "true");
+    killall_ = (uri_.getQuery("killall", "true") == "true");
 
     if (username.empty() != password.empty())
         throw SnapException("missing parameter \"username\" or \"password\" (must provide both, or neither)");
@@ -87,8 +88,11 @@ void LibrespotStream::initExeAndPath(const std::string& filename)
         exe_ = exe_.substr(exe_.find_last_of("/") + 1);
     }
 
-    /// kill if it's already running
-    execGetOutput("killall " + exe_);
+    if (killall_)
+    {
+        /// kill if it's already running
+        execGetOutput("killall " + exe_);
+    }
 }
 
 

--- a/server/streamreader/librespot_stream.hpp
+++ b/server/streamreader/librespot_stream.hpp
@@ -40,6 +40,8 @@ public:
     LibrespotStream(PcmListener* pcmListener, boost::asio::io_context& ioc, const StreamUri& uri);
 
 protected:
+    bool killall_;
+
     void onStderrMsg(const std::string& line) override;
     void initExeAndPath(const std::string& filename) override;
 };


### PR DESCRIPTION
If you want to run multiple librespot instances, they currently kill each other when they try to start. This PR adds a new `killall` option to the stream to disable this behavior.