### PR TITLE
Add Airplay cover art to metadata

### DIFF
--- a/server/control_session_tcp.cpp
+++ b/server/control_session_tcp.cpp
@@ -105,8 +105,20 @@ void ControlSessionTcp::sendAsync(const std::string& message)
 
 void ControlSessionTcp::send_next()
 {
-    auto message = messages_.front();
-    boost::asio::async_write(socket_, boost::asio::buffer(message + "\r\n"),
+    // We cannot simply do boost::asio::buffer(message + "\r\n"), because 'message + "\r\n"' becomes invalid
+    // after leaving this method, leading to a 'Bad address' error.
+    // Instead, we need to mutate the string before passing it to boost::asio::buffer.
+    //
+    // From the boost reference:
+    //
+    // A buffer object does not have any ownership of the memory it refers to. It is the responsibility of
+    // the application to ensure the memory region remains valid until it is no longer required for an I/O
+    // operation. When the memory is no longer available, the buffer is said to have been invalidated.
+    // https://www.boost.org/doc/libs/1_72_0/doc/html/boost_asio/reference/buffer.html#boost_asio.reference.buffer.buffer_invalidation
+
+    string& message = messages_.front();
+    message += "\r\n";
+    boost::asio::async_write(socket_, boost::asio::buffer(message),
                              boost::asio::bind_executor(strand_, [ this, self = shared_from_this() ](std::error_code ec, std::size_t length) {
                                  messages_.pop_front();
                                  if (ec)

--- a/server/streamreader/airplay_stream.hpp
+++ b/server/streamreader/airplay_stream.hpp
@@ -67,7 +67,9 @@ protected:
     XML_Parser parser_;
     std::unique_ptr<TageEntry> entry_;
     std::string buf_;
-    json jtag_;
+    json metadata_;
+    // set whenever metadata_ has changed
+    bool metadata_dirty_;
 #endif
 
     void pipeReadLine();
@@ -75,6 +77,7 @@ protected:
     int parse(std::string line);
     void createParser();
     void push();
+    void setMetaData(const std::string&, const std::string&);
 #endif
 
     void setParamsAndPipePathFromPort();


### PR DESCRIPTION
This adds a new "COVER" attribute to the metadata, which is supported by Airplay and contains the base64 encoded cover.
To make it work, I also had to fix an issue with the control session handler which would sometimes produce 'Bad address' errors (particularly with large covers).
I have documented more details in the comments I added.