### PR TITLE
Fix memory errors in SnapClient

### DIFF
--- a/client/client_connection.cpp
+++ b/client/client_connection.cpp
@@ -84,7 +84,7 @@ void ClientConnection::start()
     SLOG(NOTICE) << "Connected to " << socket_.remote_endpoint().address().to_string() << endl;
     active_ = true;
     sumTimeout_ = chronos::msec(0);
-    readerThread_ = new thread(&ClientConnection::reader, this);
+    readerThread_ = make_unique<thread>(&ClientConnection::reader, this);
 }
 
 
@@ -104,7 +104,6 @@ void ClientConnection::stop()
         {
             LOG(DEBUG) << "joining readerThread\n";
             readerThread_->join();
-            delete readerThread_;
         }
     }
     catch (...)

--- a/client/client_connection.hpp
+++ b/client/client_connection.hpp
@@ -156,7 +156,7 @@ protected:
     uint16_t reqId_;
     std::string host_;
     size_t port_;
-    std::thread* readerThread_;
+    std::unique_ptr<std::thread> readerThread_;
     chronos::msec sumTimeout_;
 };
 

--- a/client/controller.hpp
+++ b/client/controller.hpp
@@ -53,7 +53,7 @@
 class Controller : public MessageReceiver
 {
 public:
-    Controller(const ClientSettings& settings, std::shared_ptr<MetadataAdapter> meta);
+    Controller(const ClientSettings& settings, std::unique_ptr<MetadataAdapter> meta);
     void start();
     void run();
     void stop();
@@ -78,7 +78,7 @@ private:
     std::shared_ptr<Stream> stream_;
     std::unique_ptr<decoder::Decoder> decoder_;
     std::unique_ptr<Player> player_;
-    std::shared_ptr<MetadataAdapter> meta_;
+    std::unique_ptr<MetadataAdapter> meta_;
     std::unique_ptr<msg::ServerSettings> serverSettings_;
     std::unique_ptr<msg::CodecHeader> headerChunk_;
     std::mutex receiveMutex_;

--- a/client/decoder/flac_decoder.cpp
+++ b/client/decoder/flac_decoder.cpp
@@ -214,7 +214,7 @@ void metadata_callback(const FLAC__StreamDecoder* /*decoder*/, const FLAC__Strea
 void error_callback(const FLAC__StreamDecoder* /*decoder*/, FLAC__StreamDecoderErrorStatus status, void* client_data)
 {
     SLOG(ERROR) << "Got error callback: " << FLAC__StreamDecoderErrorStatusString[status] << "\n";
-    static_cast<FlacDecoder*>(client_data)->lastError_ = std::unique_ptr<FLAC__StreamDecoderErrorStatus>(new FLAC__StreamDecoderErrorStatus(status));
+    static_cast<FlacDecoder*>(client_data)->lastError_ = std::make_unique<FLAC__StreamDecoderErrorStatus>(status);
 }
 } // namespace callback
 

--- a/client/player/coreaudio_player.cpp
+++ b/client/player/coreaudio_player.cpp
@@ -65,13 +65,13 @@ std::vector<PcmDevice> CoreAudioPlayer::pcm_list(void)
         if (AudioObjectGetPropertyDataSize(devids[i], &theAddress, 0, NULL, &propSize))
             continue;
 
-        AudioBufferList* buflist = (AudioBufferList*)malloc(propSize);
+        AudioBufferList* buflist = new AudioBufferList[propSize];
         if (AudioObjectGetPropertyData(devids[i], &theAddress, 0, NULL, &propSize, buflist))
             continue;
         int channels = 0;
         for (UInt32 i = 0; i < buflist->mNumberBuffers; ++i)
             channels += buflist->mBuffers[i].mNumberChannels;
-        free(buflist);
+        delete[] buflist;
         if (channels == 0)
             continue;
 

--- a/client/snapclient.cpp
+++ b/client/snapclient.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
                 if (user_group.size() > 1)
                     group = user_group[1];
             }
-            daemon.reset(new Daemon(user, group, pidFile));
+            daemon = std::make_unique<Daemon>(user, group, pidFile);
             daemon->daemonize();
             if (processPriority < -20)
                 processPriority = -20;
@@ -255,12 +255,9 @@ int main(int argc, char** argv)
         if (active)
         {
             // Setup metadata handling
-            std::shared_ptr<MetadataAdapter> meta;
-            meta.reset(new MetadataAdapter);
-            if (metaStderr)
-                meta.reset(new MetaStderrAdapter);
+            auto meta(metaStderr ? std::make_unique<MetaStderrAdapter>() : std::make_unique<MetadataAdapter>());
 
-            controller = make_shared<Controller>(settings, meta);
+            controller = make_shared<Controller>(settings, std::move(meta));
             LOG(INFO) << "Latency: " << settings.player.latency << "\n";
             controller->run();
             // signal_handler.wait();

--- a/client/stream.cpp
+++ b/client/stream.cpp
@@ -225,7 +225,7 @@ cs::time_point_clk Stream::getNextPlayerChunk(void* outputBuffer, const cs::usec
         // Overwriting slices effectively corrects less frames than asked for in framesCorrection.
         slices = max;
     }
-    // Size of each slice. The last slice may be smaller.
+    // Size of each slice. The last slice may be bigger.
     int size = max / slices;
 
     // LOG(TRACE) << "getNextPlayerChunk, frames: " << framesPerBuffer << ", correction: " << framesCorrection << " (" << toRead << "), slices: " << slices
@@ -235,7 +235,7 @@ cs::time_point_clk Stream::getNextPlayerChunk(void* outputBuffer, const cs::usec
     for (size_t n = 0; n < slices; ++n)
     {
         if (n + 1 == slices)
-            // Adjust size in the last iteration, because the last slice may be smaller
+            // Adjust size in the last iteration, because the last slice may be bigger
             size = max - pos;
 
         if (framesCorrection < 0)

--- a/client/stream.hpp
+++ b/client/stream.hpp
@@ -40,7 +40,7 @@ public:
     Stream(const SampleFormat& format);
 
     /// Adds PCM data to the queue
-    void addChunk(msg::PcmChunk* chunk);
+    void addChunk(std::unique_ptr<msg::PcmChunk> chunk);
     void clearChunks();
 
     /// Get PCM data, which will be played out in "outputBufferDacTime" time


### PR DESCRIPTION
I noticed that the SnapClient would cause more and more audio dropouts (~1sec) the longer I let it running. The logs look just fine when most of the dropouts happen.

Example (a short dropout happened at 18-32-52 but there is no sign of it in the logs): 
```
2020-02-11 18-32-42 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 18-32-43 [Info] Chunk: 0	0	0	0	500	89
2020-02-11 18-32-44 [Info] Chunk: 1	0	0	0	500	60
2020-02-11 18-32-45 [Info] Chunk: 1	0	0	0	500	60
2020-02-11 18-32-46 [Info] Chunk: 1	1	0	0	500	89
2020-02-11 18-32-47 [Info] Chunk: 1	1	1	0	500	60
2020-02-11 18-32-48 [Info] Chunk: 1	1	1	0	500	60
2020-02-11 18-32-49 [Info] Chunk: 0	0	1	0	500	89
2020-02-11 18-32-50 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 18-32-51 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 18-32-52 [Info] Chunk: 0	0	0	0	500	89
2020-02-11 18-32-53 [Info] Chunk: 1	0	0	0	500	60
2020-02-11 18-32-54 [Info] Chunk: 1	1	0	0	500	60
2020-02-11 18-32-55 [Info] Chunk: 1	1	0	0	500	60
2020-02-11 18-32-56 [Info] Chunk: 1	1	1	0	500	89
2020-02-11 18-32-57 [Info] Chunk: 1	1	1	0	500	60
```

But then another dropout happened, this time with something interesting in the logs:

```
2020-02-11 19-07-38 [Info] Chunk: 0	0	0	0	500	89
2020-02-11 19-07-39 [Info] Chunk: 0	0	0	0	500	89
2020-02-11 19-07-40 [Info] Chunk: 1	1	0	0	500	60
2020-02-11 19-07-41 [Info] Chunk: 1	1	0	0	500	60
2020-02-11 19-07-42 [Info] Chunk: 1	1	1	0	500	60
2020-02-11 19-07-43 [Info] Chunk: 0	0	1	0	500	89
2020-02-11 19-07-44 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 19-07-45 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 19-07-46 [Info] Chunk: M0ai	n loop
2020-02-11 19-07-46 [Info] 0	0	0	500	89
2020-02-11 19-07-47 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 19-07-48 [Info] Chunk: 0	0	0	0	500	60
2020-02-11 19-07-49 [Info] Chunk: 0	0	0	0	500	89
2020-02-11 19-07-50 [Info] Chunk: 1	0	0	0	500	60
2020-02-11 19-07-51 [Info] Chunk: 1	1	0	0	500	60
2020-02-11 19-07-52 [Info] Chunk: 0	1	0	0	500	89
2020-02-11 19-07-53 [Info] Chunk: 1	1	1	0	500	60
2020-02-11 19-07-54 [Info] Chunk: 0	1	1	0	500	59
```

To me this looks like some sort of memory issue. Notice how I did *not* enable the `--debug` option, but somehow `Main loop` is mangled into the logs.

To mitigate potential memory issues, I first replaced most occurrences of `new` and `malloc` in the client by their C++ equivalents (first commit).

I then ran the client using valgrind (`valgrind --leak-check=yes ./bin/snapclient ...`) which showed this error:

```
==26315== Argument 'size' of function __builtin_vec_new has a fishy (possibly negative) value: -16
==26315==    at 0x4C3089F: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26315==    by 0x2985CB: Stream::getNextPlayerChunk(void*, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, unsigned long, long) (stream.cpp:215)
==26315==    by 0x29A0AD: Stream::getPlayerChunk(void*, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, unsigned long) (stream.cpp:426)
==26315==    by 0x2AD6B1: AlsaPlayer::worker() (alsa_player.cpp:238)
==26315==    by 0x2A680F: void std::__invoke_impl<void, void (Player::*)(), Player*>(std::__invoke_memfun_deref, void (Player::*&&)(), Player*&&) (invoke.h:73)
==26315==    by 0x2A62CB: std::__invoke_result<void (Player::*)(), Player*>::type std::__invoke<void (Player::*)(), Player*>(void (Player::*&&)(), Player*&&) (invoke.h:95)
==26315==    by 0x2A6AC4: decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)())) std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (thread:244)
==26315==    by 0x2A6A6A: std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> >::operator()() (thread:253)
==26315==    by 0x2A6A3F: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> > >::_M_run() (thread:196)
==26315==    by 0x613166E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
==26315==    by 0x4E436DA: start_thread (pthread_create.c:463)
==26315==    by 0x6AD488E: clone (clone.S:95)
```

The second commit fixes the memory issues inside the `getNextPlayerChunk` method. I also refactored it slightly and added some comments to make it easier to understand. Let me know what you think.