### PR TITLE
update build doc for mac

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -167,13 +167,16 @@ To enable the serve and client to start under the default run-level:
 
 ## macOS (Native)
 
-*Warning: macOS support is experimental*
+ 1. Install Xcode from the App Store or use:
 
- 1. Install Xcode from the App Store
+```
+$ xcode-select --install
+```
+
  2. Install [Homebrew](http://brew.sh)
- 3. Install the required libs
+ 3. Install the required libs:
 
-```   
+```
 $ brew install flac libvorbis boost opus
 ```
 


### PR DESCRIPTION
remove the mention of macOS support being experimental, as master now has the fixes from issues now resolved and tested.
Also added a cli alternative for xcode install.