### PR TITLE
Initialize correctAfterXFrames_

### DIFF
--- a/client/stream.cpp
+++ b/client/stream.cpp
@@ -32,7 +32,7 @@ static constexpr auto kCorrectionBegin = 100us;
 
 Stream::Stream(const SampleFormat& in_format, const SampleFormat& out_format)
     : in_format_(in_format), median_(0), shortMedian_(0), lastUpdate_(0), playedFrames_(0), bufferMs_(cs::msec(500)), soxr_(nullptr), frame_delta_(0),
-      hard_sync_(true)
+      hard_sync_(true), correctAfterXFrames_(0)
 {
     buffer_.setSize(500);
     shortBuffer_.setSize(100);


### PR DESCRIPTION
`correctAfterXFrames_` was not initialized. I noticed this because I was running Valgrind and got:

```
==16387== Thread 4:
==16387== Conditional jump or move depends on uninitialised value(s)
==16387==    at 0x29DD8B: Stream::getPlayerChunk(void*, std::chrono::duration<long, std::ratio<1l, 1000000l> > const&, unsigned int) (stream.cpp:411)
==16387==    by 0x2B2297: AlsaPlayer::worker() (alsa_player.cpp:243)
==16387==    by 0x2AB325: void std::__invoke_impl<void, void (Player::*)(), Player*>(std::__invoke_memfun_deref, void (Player::*&&)(), Player*&&) (invoke.h:73)
==16387==    by 0x2AADE1: std::__invoke_result<void (Player::*)(), Player*>::type std::__invoke<void (Player::*)(), Player*>(void (Player::*&&)(), Player*&&) (invoke.h:95)
==16387==    by 0x2AB5DA: decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)())) std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (thread:244)
==16387==    by 0x2AB580: std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> >::operator()() (thread:253)
==16387==    by 0x2AB555: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (Player::*)(), Player*> > >::_M_run() (thread:196)
==16387==    by 0x639466E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
==16387==    by 0x4E436DA: start_thread (pthread_create.c:463)
==16387==    by 0x6D3788E: clone (clone.S:95)
==16387== 
```