### PR TITLE
Update Fedora dependencies

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -42,7 +42,7 @@ For Arch derivates:
 For Fedora (and probably RHEL, CentOS, & Scientific Linux, but untested):
 
     $ sudo dnf install @development-tools
-    $ sudo dnf install alsa-lib-devel avahi-devel libvorbis-devel opus-devel flac-devel soxr-devel libstdc++-static expat
+    $ sudo dnf install alsa-lib-devel avahi-devel libvorbis-devel opus-devel flac-devel soxr-devel libstdc++-static expat boost-devel
 
 ### Build Snapclient and Snapserver
 `cd` into the Snapcast src-root directory:


### PR DESCRIPTION
Compiling on Fedora 31 with the recommended dependencies installed compilation failed returning the following error:

`In Datei, eingebunden von controller.hpp:40,
                 von snapclient.cpp:25:
client_connection.hpp:25:10: schwerwiegender Fehler: boost/asio.hpp: Datei oder Verzeichnis nicht gefunden
   25 | #include <boost/asio.hpp>
      |          ^~~~~~~~~~~~~~~~
Kompilierung beendet.`



I fixed it by installing boost-devel.