### PR TITLE
Allow usage of boost in different prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,8 @@ endif()
 
 find_package(Boost 1.70 REQUIRED)
 add_definitions("-DBOOST_ERROR_CODE_HEADER_ONLY")
+include_directories(${Boost_INCLUDE_DIRS})
+link_directories(${BOOST_LIBRARY_DIRS})
 
 if(WIN32)
 	include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Right now, even if `CMAKE_PREFIX_PATH` for instance is set and points to an up-to-date boost, CMake will just link to the system boost, as it is never told where the right headers and libraries are.

A far more superior solution would be to require a CMake version 3.5+ and use the imported targets FindBoost provides (`Boost::*`).

See https://cmake.org/cmake/help/v3.5/module/FindBoost.html for more information.

---

I've been compiling snapcast just fine on Ubuntu bionic with some Boost 1.72 built from source and installed into a custom prefix using this commit.

I'd strongly recommend reviewing the entire linking in the CMake configuration, and go for proper targets where possible instead of relying on . Most `Find*` files nowadays provide imported targets, same goes for the `pkg-config` integration (starting with CMake 3.6 IIRC). That way, you can ensure everything's linked to the libraries the user intended to use. This PR is merely a "hotfix", since I needed to get snapcast running on an LTS distro.

I'm not sure by the way why the `{SERVER,CLIENT}_INCLUDE` lists have worked as intended. But `link_directories` was definitely missing. As said, using imported targets will eliminate most of these annoyances, as linking to an imported target usually also configures the include dirs etc.