### PR TITLE
submodules: update Xiph's remote to GitLab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "externals/flac"]
 	path = externals/flac
-	url = https://git.xiph.org/flac.git
+	url = https://gitlab.xiph.org/xiph/flac.git
 [submodule "externals/ogg"]
 	path = externals/ogg
-	url = https://git.xiph.org/ogg.git
+	url = https://gitlab.xiph.org/xiph/ogg.git
 [submodule "externals/tremor"]
 	path = externals/tremor
-	url = https://git.xiph.org/tremor.git
+	url = https://gitlab.xiph.org/xiph/tremor.git
 [submodule "externals/opus"]
 	path = externals/opus
-	url = https://git.xiph.org/opus.git
+	url = https://gitlab.xiph.org/xiph/opus.git
 [submodule "externals/oboe"]
 	path = externals/oboe
 	url = https://github.com/google/oboe.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://gitlab.xiph.org/xiph/ogg.git
 [submodule "externals/tremor"]
 	path = externals/tremor
-	url = https://gitlab.xiph.org/xiph/tremor.git
+	url = https://github.com/badaix/tremor.git
 [submodule "externals/opus"]
 	path = externals/opus
 	url = https://gitlab.xiph.org/xiph/opus.git


### PR DESCRIPTION
While I migrated the OpenWrt build from 0.19.0 to 0.20.0, I got build error:
```
fatal: unable to access 'https://git.xiph.org/ogg.git/': Failed to
connect to git.xiph.org port 443: Connection timed out
```
![image](https://user-images.githubusercontent.com/568751/81484794-d3fb8c00-9248-11ea-99ed-e094f63f28d5.png)

They moved development, **but missed two commits from tremor** (reported as [xiph/tremor#2298](https://gitlab.xiph.org/xiph/tremor/-/issues/2298)).

I found the missing commits in a mirror, here in GitHub:
vrgl117-games/tremor@7c30a66346199f3f09017a09567c6c8a3a0eedc8.

What now?