### PR TITLE
Add &params= option to librespot to support other librespot parameters

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -38,7 +38,7 @@ pipe:///<path/to/pipe>?name=<name>[&mode=create][&dryout_ms=2000]
 Launches librespot and reads audio from stdout
 
 ```sh
-librespot:///<path/to/librespot>?name=<name>[&dryout_ms=2000][&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&wd_timeout=7800][&volume=100][&onevent=""][&normalize=false][&autoplay=false][&cache=""][&disable_audio_cache=false][&killall=true]
+librespot:///<path/to/librespot>?name=<name>[&dryout_ms=2000][&username=<my username>&password=<my password>][&devicename=Snapcast][&bitrate=320][&wd_timeout=7800][&volume=100][&onevent=""][&normalize=false][&autoplay=false][&cache=""][&disable_audio_cache=false][&killall=true][&params=extra-params]
 ```
 
 Note that you need to have the librespot binary on your machine and the sampleformat will be set to `44100:16:2`
@@ -57,6 +57,7 @@ Parameters used to configure the librespot binary ([see librespot-org options](h
 - `autoplay`: Autoplay similar songs when your music ends
 - `cache`: Path to a directory where files will be cached
 - `disable_audio_cache`: Disable caching of the audio data
+- `params`: Optional string appended to the librespot invocation. This allows for arbitrary flags to be passed to librespot, for instance `params=--device-type%20avr`. The value has to be properly URL-encoded.
 
 Parameters introduced by Snapclient:
 

--- a/server/streamreader/librespot_stream.cpp
+++ b/server/streamreader/librespot_stream.cpp
@@ -51,7 +51,7 @@ LibrespotStream::LibrespotStream(PcmListener* pcmListener, boost::asio::io_conte
     if (username.empty() != password.empty())
         throw SnapException("missing parameter \"username\" or \"password\" (must provide both, or neither)");
 
-    params_ = "--name \"" + devicename + "\"";
+    params_ += "--name \"" + devicename + "\"";
     if (!username.empty() && !password.empty())
         params_ += " --username \"" + username + "\" --password \"" + password + "\"";
     params_ += " --bitrate " + bitrate + " --backend pipe";


### PR DESCRIPTION
On my firewall'd machine, I need to specify a deterministic [zeroconf port](https://github.com/librespot-org/librespot/wiki/Options#:~:text=zeroconf-port) so I can open it explicitly, otherwise librespot mDNS announcement/discovery won't work.

Rather than adding a bunch of very niche query parameters, in this PR I suggest allowing an arbitrary &params=foo that is appended to librespot command line. This makes the code future-proof for new releases of librespot that introduce new options: for instance, `--zeroconf-port` and `--device-type` are two things I want to set on librespot from Snapcast server.

Documentation update is included.