### PR TITLE
Snapweb: increase compatibility with older browsers

### DIFF
--- a/server/etc/snapweb/snapstream.js
+++ b/server/etc/snapweb/snapstream.js
@@ -452,8 +452,6 @@ class TimeProvider {
         if (ctx) {
             this.setAudioContext(ctx);
         }
-        let userAgent = navigator.userAgent.toLowerCase();
-        this.isFirefoxMobile = (userAgent.indexOf('firefox') > -1) && (userAgent.indexOf('android') > -1);
     }
     setAudioContext(ctx) {
         this.ctx = ctx;
@@ -478,16 +476,13 @@ class TimeProvider {
         // console.log("now: " + this.now() + "\t" + this.now() + "\t" + this.now());
     }
     now() {
+        // No context yet. Fallback to performance.now().
         if (!this.ctx) {
             return window.performance.now();
         }
         else {
-            if (this.isFirefoxMobile) {
-                return this.ctx.currentTime * 1000;
-            }
-            else {
-                return (this.ctx.getOutputTimestamp().contextTime || this.ctx.currentTime) * 1000;
-            }
+            // getOutputTimestamp is experimental, fallback to ctx.currentTime if not available.
+            return (!!this.ctx.getOutputTimestamp ? this.ctx.getOutputTimestamp().contextTime : this.ctx.currentTime) * 1000;
         }
     }
     nowSec() {
@@ -727,7 +722,12 @@ class SnapStream {
                             this.bufferFrameCount = Math.floor(this.bufferDurationMs * this.sampleFormat.msRate());
                         }
                         this.stopAudio();
-                        this.ctx = new AudioContext({ latencyHint: "playback", sampleRate: this.sampleFormat.rate });
+                        let options = { latencyHint: "playback", sampleRate: this.sampleFormat.rate };
+                        if (navigator.userAgent.match(/Chrome\/53\.0\./)) {
+                            // Some older browsers won't decode the stream if options are provided.
+                            options = undefined;
+                        }
+                        this.ctx = new AudioContext(options);
                         this.timeProvider.setAudioContext(this.ctx);
                         this.gainNode = this.ctx.createGain();
                         this.gainNode.connect(this.ctx.destination);


### PR DESCRIPTION
Two things:

* using `this.ctx.getOutputTimestamp().contextTime || (fallback)` does not have the intended effect of falling back if `getOutputTimestamp` doesn't exist because then calling it throws a JS exception (infamous *undefined is not a function*). This PR fixes the problem by checking the function exists first.
* I'm running Snapweb on a smart TV with an ancient Chrome build (53.0 from 2016) and can only get it to work if `AudioContext` has no constructor options.

Side note: what's the status of this code compared to the more recent Typescript version that live at https://github.com/badaix/snapweb? Should I update both?