### PR TITLE
Add issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: 'Report a bug '
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+**Steps to Reproduce**
+1.
+2.
+3.
+
+**Used snapcast version**
+
+**Attach logfile if applicable**
+Generate logs with `snapclient --logfilter debug` or `snapserver --logging.filter debug` if possible and paste them in the following codeblock
+```
+# Replace this with your logs
+```

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for snapcast
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+**Describe the solution you'd like**
+
+**Optional: Describe alternatives you've considered**


### PR DESCRIPTION
This PR adds github issue templates to the project, so it's clear to users what you expect from them when they open an issue. E.g. in #704 the author forgot to include logs, which probably will happen to most users because nearly no issue reporter will read the whole contributing.md file. 

For that reason I added the templates by combining the default templates from github with the stuff of the contributing.md. Feel free to modify any wording etc. in the PR, I mostly wanted to make you aware of this nice github feature which will probably save you some nerves... 

It also automatically applies labels, which otherwise is not possible on Github for non maintainers if I'm not mistaken.

You can see it in action in my fork, see https://github.com/l3d00m/snapcast/issues/new/choose (feel free to try it out there, I'll delete the fork anyways after this PR is finished)