### PR TITLE
Fix markdown for json rpc api documentation, minor improvement to api documentation

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: c:\vcpkg\installed
+        path: $env:VCPKG_INSTALLATION_ROOT\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -27,12 +27,12 @@ jobs:
       run: cmake --build build --config Release --parallel 3 --verbose
     - name: installer
       run: |
-        copy c:\vcpkg\installed\x64-windows\bin\FLAC.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\ogg.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\opus.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\vorbis.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\opus.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy $env:VCINSTALLDIR\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,17 +25,25 @@ jobs:
         cmake -S . -B build -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows" -DCMAKE_BUILD_TYPE="Release"
     - name: cmake make
       run: cmake --build build --config Release --parallel 3 --verbose
+    - name: installer
+      run: |
+        copy c:\vcpkg\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\opus.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:
         name: develop_snapshot_win64-${{github.sha}}
         path: |
           bin\Release\snapclient.exe
-          c:\vcpkg\installed\x64-windows\bin\FLAC.dll
-          c:\vcpkg\installed\x64-windows\bin\ogg.dll
-          c:\vcpkg\installed\x64-windows\bin\opus.dll
-          c:\vcpkg\installed\x64-windows\bin\vorbis.dll
-          c:\vcpkg\installed\x64-windows\bin\soxr.dll
-          %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe
+          bin\Release\FLAC.dll
+          bin\Release\ogg.dll
+          bin\Release\opus.dll
+          bin\Release\vorbis.dll
+          bin\Release\soxr.dll
+          bin\Release\vc_redist.x64.exe
  
  

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: $env:VCPKG_INSTALLATION_ROOT\installed
+        path: ${env:VCPKG_INSTALLATION_ROOT}\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -27,12 +27,12 @@ jobs:
       run: cmake --build build --config Release --parallel 3 --verbose
     - name: installer
       run: |
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\FLAC.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\ogg.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\opus.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\vorbis.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy $env:VCINSTALLDIR\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\opus.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy ${env:VCINSTALLDIR}\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,7 @@ jobs:
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\opus.dll bin\Release\
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\vorbis.dll bin\Release\
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy ${env:VCINSTALLDIR}\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\vc_redist.x64.exe" bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: ${env:VCPKG_INSTALLATION_ROOT}\installed
+        path: c:\vcpkg\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,5 +29,13 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: develop_snapshot_win64-${{github.sha}}
-        path: bin\Release\snapclient.exe
+        path: |
+          bin\Release\snapclient.exe
+          c:\vcpkg\installed\x64-windows\bin\FLAC.dll
+          c:\vcpkg\installed\x64-windows\bin\ogg.dll
+          c:\vcpkg\installed\x64-windows\bin\opus.dll
+          c:\vcpkg\installed\x64-windows\bin\vorbis.dll
+          c:\vcpkg\installed\x64-windows\bin\soxr.dll
+          %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe
+ 
  

--- a/doc/json_rpc_api/v2_0_0.md
+++ b/doc/json_rpc_api/v2_0_0.md
@@ -185,12 +185,12 @@ The Server JSON object contains a list of Groups and Streams. Every Group holds 
 ### Client.SetVolume
 #### Request
 ```json
-{"id":8,"jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}
+{"id":"ids can be a string as well","jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}
 ```
 
 #### Response
 ```json
-{"id":8,"jsonrpc":"2.0","result":{"volume":{"muted":false,"percent":74}}}
+{"id":"ids can be a string as well","jsonrpc":"2.0","result":{"volume":{"muted":false,"percent":74}}}
 ```
 
 #### Notification
@@ -385,7 +385,7 @@ The Server JSON object contains a list of Groups and Streams. Every Group holds 
 
 ### Client.OnVolumeChanged
 ```json
-{"jsonrpc":"2.0","method":"Client.OnVolumeChanged","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}```
+{"jsonrpc":"2.0","method":"Client.OnVolumeChanged","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}
 ```
 
 ### Client.OnLatencyChanged

--- a/doc/json_rpc_api/v2_0_0.md
+++ b/doc/json_rpc_api/v2_0_0.md
@@ -101,6 +101,11 @@ WebSockets receive Notifications of events. Connect a client, and you will event
 The client that sends a "Set" command will receive a Response, while the other connected control clients will receive a Notification "On" event.
 Commands can be sent in a [Batch](http://www.jsonrpc.org/specification#batch). The server will reply with a Batch and send a Batch notification to the other clients. This way the volume of multiple Snapclients can be changed with a single Batch Request.
 
+Each JSON RPC request and response contains an identifier in the `id` field, which can be used to link responses to the request that caused them, as defined in the  JSON RPC specification:
+
+    An identifier established by the Client that MUST contain a String, Number, or NULL value if included. 
+    If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
+
 Clients should call `Server.GetStatus` to get the complete picture. 
 
 The Server JSON object contains a list of Groups and Streams. Every Group holds a list of Clients and a reference to a Stream. Clients, Groups and Streams are referenced in the "Set" commands by their `id`.
@@ -185,12 +190,12 @@ The Server JSON object contains a list of Groups and Streams. Every Group holds 
 ### Client.SetVolume
 #### Request
 ```json
-{"id":"ids can be a string as well","jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}
+{"id":"8","jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"00:21:6a:7d:74:fc","volume":{"muted":false,"percent":74}}}
 ```
 
 #### Response
 ```json
-{"id":"ids can be a string as well","jsonrpc":"2.0","result":{"volume":{"muted":false,"percent":74}}}
+{"id":"8","jsonrpc":"2.0","result":{"volume":{"muted":false,"percent":74}}}
 ```
 
 #### Notification
@@ -410,7 +415,7 @@ The Server JSON object contains a list of Groups and Streams. Every Group holds 
 
 ### Group.OnNameChanged
 ```json
-{"jsonrpc":"2.0","method":"GrClient.OnNameChanged","params":{"id":"4dcc4e3b-c699-a04b-7f0c-8260d23c43e1","name":"GroundFloor"}}
+{"jsonrpc":"2.0","method":"Group.OnNameChanged","params":{"id":"4dcc4e3b-c699-a04b-7f0c-8260d23c43e1","name":"GroundFloor"}}
 ```
 
 ### Stream.OnUpdate


### PR DESCRIPTION
Fix a markdown type (duplicate ```) and add an example with a string as jsonrpc id to make it clear that not only integers are supported.

I branched of from master, so some commits which are pushed to master but not development have gotten into this PR as well. You can resolve this by merging master to development or by rebasing development on master prior to reviewing this PR.