### PR TITLE
Update build.md

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: c:\vcpkg\installed
+        path: $env:VCPKG_INSTALLATION_ROOT\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -27,12 +27,12 @@ jobs:
       run: cmake --build build --config Release --parallel 3 --verbose
     - name: installer
       run: |
-        copy c:\vcpkg\installed\x64-windows\bin\FLAC.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\ogg.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\opus.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\vorbis.dll bin\Release\
-        copy c:\vcpkg\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\opus.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy $env:VCINSTALLDIR\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,17 +25,25 @@ jobs:
         cmake -S . -B build -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows" -DCMAKE_BUILD_TYPE="Release"
     - name: cmake make
       run: cmake --build build --config Release --parallel 3 --verbose
+    - name: installer
+      run: |
+        copy c:\vcpkg\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\opus.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy c:\vcpkg\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:
         name: develop_snapshot_win64-${{github.sha}}
         path: |
           bin\Release\snapclient.exe
-          c:\vcpkg\installed\x64-windows\bin\FLAC.dll
-          c:\vcpkg\installed\x64-windows\bin\ogg.dll
-          c:\vcpkg\installed\x64-windows\bin\opus.dll
-          c:\vcpkg\installed\x64-windows\bin\vorbis.dll
-          c:\vcpkg\installed\x64-windows\bin\soxr.dll
-          %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe
+          bin\Release\FLAC.dll
+          bin\Release\ogg.dll
+          bin\Release\opus.dll
+          bin\Release\vorbis.dll
+          bin\Release\soxr.dll
+          bin\Release\vc_redist.x64.exe
  
  

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: $env:VCPKG_INSTALLATION_ROOT\installed
+        path: ${env:VCPKG_INSTALLATION_ROOT}\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -27,12 +27,12 @@ jobs:
       run: cmake --build build --config Release --parallel 3 --verbose
     - name: installer
       run: |
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\FLAC.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\ogg.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\opus.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\vorbis.dll bin\Release\
-        copy $env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy $env:VCINSTALLDIR\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\FLAC.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\ogg.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\opus.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\vorbis.dll bin\Release\
+        copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\soxr.dll bin\Release\
+        copy ${env:VCINSTALLDIR}\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,7 @@ jobs:
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\opus.dll bin\Release\
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\vorbis.dll bin\Release\
         copy ${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows\bin\soxr.dll bin\Release\
-        copy ${env:VCINSTALLDIR}\Redist\MSVC\v142\vc_redist.x64.exe bin\Release\
+        copy "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\vc_redist.x64.exe" bin\Release\
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/cache@v2
       with:
         #path: ${VCPKG_INSTALLATION_ROOT}\installed
-        path: ${env:VCPKG_INSTALLATION_ROOT}\installed
+        path: c:\vcpkg\installed
         key: ${{ runner.os }}-dependencies
     - name: dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,5 +29,13 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: develop_snapshot_win64-${{github.sha}}
-        path: bin\Release\snapclient.exe
+        path: |
+          bin\Release\snapclient.exe
+          c:\vcpkg\installed\x64-windows\bin\FLAC.dll
+          c:\vcpkg\installed\x64-windows\bin\ogg.dll
+          c:\vcpkg\installed\x64-windows\bin\opus.dll
+          c:\vcpkg\installed\x64-windows\bin\vorbis.dll
+          c:\vcpkg\installed\x64-windows\bin\soxr.dll
+          %VCINSTALLDIR%Redist\MSVC\v142\vc_redist.x64.exe
+ 
  

--- a/doc/build.md
+++ b/doc/build.md
@@ -43,7 +43,7 @@ For Debian derivates (e.g. Raspbian, Debian, Ubuntu, Mint):
 
 ```sh
 sudo apt-get install build-essential
-sudo apt-get install libasound2-dev libvorbisidec-dev libvorbis-dev libopus-dev libflac-dev libsoxr-dev alsa-utils libavahi-client-dev avahi-daemon libexpat1-dev
+sudo apt-get install libboost-dev libasound2-dev libvorbisidec-dev libvorbis-dev libopus-dev libflac-dev libsoxr-dev alsa-utils libavahi-client-dev avahi-daemon libexpat1-dev
 ```
 
 Compilation requires gcc 4.8 or higher, so it's highly recommended to use Debian (Raspbian) Jessie.


### PR DESCRIPTION
libboost-dev was missing among the packages required to build on deb-based systems (at least that was necessary on raspberry pi os).

It is only a minor addition to the documentation.