### PR TITLE
DOCS: Add option for line-in

### DIFF
--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -256,9 +256,8 @@ WantedBy=multi-user.target
 Replace $USER with the username whom can run the preceding command succesfully. Finally run:
 ```
 sudo systemctl daemon-reload
-sudo service sox start
-sudo service sox enable
-sudo service sox status
+sudo systemctl enable --now sox
+sudo systemctl status sox
 ```
 to start the service, automatically start it at boot and check if it is working.
 


### PR DESCRIPTION
Can be used for multiple setups, including edge cases where only a single channel is desired. Cpiped nor parec work in these cases.
