### PR TITLE
Wasapi player: unregister system volume change callback on player destroy

### DIFF
--- a/client/player/wasapi_player.cpp
+++ b/client/player/wasapi_player.cpp
@@ -83,6 +83,7 @@ WASAPIPlayer::WASAPIPlayer(boost::asio::io_context& io_context, const ClientSett
 
 WASAPIPlayer::~WASAPIPlayer()
 {
+    audioEndpointListener_->UnregisterControlChangeNotify(&audioEndpointVolumeCallback_);
     WASAPIPlayer::stop();
 }
 
@@ -250,10 +251,9 @@ void WASAPIPlayer::worker()
     hr = control->RegisterAudioSessionNotification(audioEventListener_);
     CHECK_HR(hr);
 
-    AudioEndpointVolumeCallback audioEndpointVolumeCallback;
     hr = device->Activate(IID_IAudioEndpointVolume, CLSCTX_ALL, NULL, (void**)&audioEndpointListener_);
 
-    audioEndpointListener_->RegisterControlChangeNotify((IAudioEndpointVolumeCallback*)&audioEndpointVolumeCallback);
+    audioEndpointListener_->RegisterControlChangeNotify((IAudioEndpointVolumeCallback*)&audioEndpointVolumeCallback_);
 
     // Get the device period
     REFERENCE_TIME hnsRequestedDuration = REFTIMES_PER_SEC;

--- a/client/player/wasapi_player.hpp
+++ b/client/player/wasapi_player.hpp
@@ -192,6 +192,7 @@ protected:
 private:
     AudioSessionEventListener* audioEventListener_;
     IAudioEndpointVolume* audioEndpointListener_;
+    AudioEndpointVolumeCallback audioEndpointVolumeCallback_;
     ClientSettings::SharingMode mode_;
 };
 


### PR DESCRIPTION
Hi! This fixes a crash on Windows which occurs when the user changes the system volume after the WasapiPlayer has been destroyed and recreated (eg. switching streams). The system would attempt to invoke a callback on a WasapiPlayer instance that no longer exists, causing the crash. Fixed by unregistering this callback in the destructor.

See https://github.com/stijnvdb88/Snap.Net/issues/5

Tests passed: Change Windows volume before and after switching streams, regular playback