### PR TITLE
Refactor volume processing to separate class SoftwareDsp

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CLIENT_SOURCES
     time_provider.cpp
     decoder/pcm_decoder.cpp
     player/player.cpp
-    player/file_player.cpp)
+    player/file_player.cpp
+    player/software_dsp.cpp)
 
 set(CLIENT_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${ATOMIC_LIBRARY} common)
 

--- a/client/player/player.cpp
+++ b/client/player/player.cpp
@@ -49,6 +49,8 @@ static constexpr auto LOG_TAG = "Player";
 Player::Player(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream)
     : io_context_(io_context), active_(false), stream_(stream), settings_(settings), volume_(1.0), muted_(false), volCorrection_(1.0)
 {
+    dsp_ = std::make_unique<SoftwareDsp>(stream_->getFormat());
+
     string sharing_mode;
     switch (settings_.sharing_mode)
     {
@@ -165,16 +167,7 @@ void Player::adjustVolume(char* buffer, size_t frames)
         volume *= volCorrection_;
     }
 
-    if (volume != 1.0)
-    {
-        const SampleFormat& sampleFormat = stream_->getFormat();
-        if (sampleFormat.sampleSize() == 1)
-            adjustVolume<int8_t>(buffer, frames * sampleFormat.channels(), volume);
-        else if (sampleFormat.sampleSize() == 2)
-            adjustVolume<int16_t>(buffer, frames * sampleFormat.channels(), volume);
-        else if (sampleFormat.sampleSize() == 4)
-            adjustVolume<int32_t>(buffer, frames * sampleFormat.channels(), volume);
-    }
+    dsp_->adjustVolume(buffer, frames, volume);
 }
 
 

--- a/client/player/player.hpp
+++ b/client/player/player.hpp
@@ -22,6 +22,7 @@
 #include "client_settings.hpp"
 #include "common/aixlog.hpp"
 #include "common/endian.hpp"
+#include "software_dsp.hpp"
 #include "stream.hpp"
 
 #include <boost/asio.hpp>
@@ -97,6 +98,7 @@ protected:
 
     boost::asio::io_context& io_context_;
     std::atomic<bool> active_;
+    std::unique_ptr<SoftwareDsp> dsp_;
     std::shared_ptr<Stream> stream_;
     std::thread playerThread_;
     ClientSettings::Player settings_;
@@ -105,15 +107,6 @@ protected:
     double volCorrection_;
     volume_callback onVolumeChanged_;
     mutable std::mutex mutex_;
-
-private:
-    template <typename T>
-    void adjustVolume(char* buffer, size_t count, double volume)
-    {
-        T* bufferT = (T*)buffer;
-        for (size_t n = 0; n < count; ++n)
-            bufferT[n] = endian::swap<T>(static_cast<T>(endian::swap<T>(bufferT[n]) * volume));
-    }
 };
 
 } // namespace player

--- a/client/player/software_dsp.cpp
+++ b/client/player/software_dsp.cpp
@@ -1,0 +1,45 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2021  Manuel Weichselbaumer
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "software_dsp.hpp"
+
+namespace player
+{
+
+SoftwareDsp::SoftwareDsp(const SampleFormat& out_format) : out_format_(out_format)
+{
+}
+
+SoftwareDsp::~SoftwareDsp()
+{
+}
+
+void SoftwareDsp::adjustVolume(char* buffer, size_t frames, double volume)
+{
+    if (volume != 1.0)
+    {
+        if (out_format_.sampleSize() == 1)
+            adjustVolume<int8_t>(buffer, frames * out_format_.channels(), volume);
+        else if (out_format_.sampleSize() == 2)
+            adjustVolume<int16_t>(buffer, frames * out_format_.channels(), volume);
+        else if (out_format_.sampleSize() == 4)
+            adjustVolume<int32_t>(buffer, frames * out_format_.channels(), volume);
+    }
+}
+
+} // namespace player

--- a/client/player/software_dsp.hpp
+++ b/client/player/software_dsp.hpp
@@ -1,0 +1,58 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2021  Manuel Weichselbaumer
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#ifndef SOFTWARE_DSP_HPP
+#define SOFTWARE_DSP_HPP
+
+#include "common/endian.hpp"
+#include "common/sample_format.hpp"
+
+namespace player
+{
+
+/// Software DSP
+/**
+ * Software DSP to handle all sample processing like volume or equalizer.
+ */
+class SoftwareDsp
+{
+public:
+    SoftwareDsp(const SampleFormat& out_format);
+    virtual ~SoftwareDsp();
+
+    /// process buffer to apply volume
+    /// @param buffer the raw data to process
+    /// @param frames the number of frames to process
+    /// @param volume the volume to apply
+    void adjustVolume(char* buffer, size_t frames, double volume);
+
+private:
+    SampleFormat out_format_;
+
+    template <typename T>
+    static void adjustVolume(char* buffer, size_t count, double volume)
+    {
+        T* bufferT = (T*)buffer;
+        for (size_t n = 0; n < count; ++n)
+            bufferT[n] = endian::swap<T>(static_cast<T>(endian::swap<T>(bufferT[n]) * volume));
+    }
+};
+
+} // namespace player
+
+#endif // SOFTWARE_DSP_HPP


### PR DESCRIPTION
This change moves the volume processing to a dedicated class called SoftwareDsp.
My goal is to provide a central point for any buffer manipulations (e.g. equalizing).