### PR TITLE
Make it possible to override sampleformat for librespot streams

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -64,6 +64,16 @@ Parameters introduced by Snapclient:
 - `killall`: Kill all running librespot instances before launching librespot
 - `wd_timeout`: Restart librespot if it doesn't create log messages for x seconds
 
+#### Configuring 24 bits sample format
+
+Note: this requires librespot >= 0.2.0.
+
+To get 24 bits sample format from librespot, you need to both instruct librespot to stream in 24 bit and set `sampleformat` for the stream (as it does not inherit the default `sampleformat` set in the server config).
+
+```
+librespot:///<your-librespot-config>&sampleformat=44100:24:2&params=--format=S24
+```
+
 ### airplay
 
 Launches [shairport-sync](https://github.com/mikebrady/shairport-sync) and reads audio from stdout

--- a/server/streamreader/stream_manager.cpp
+++ b/server/streamreader/stream_manager.cpp
@@ -93,7 +93,9 @@ PcmStreamPtr StreamManager::addStream(StreamUri& streamUri)
         // Overwrite sample format here instead of inside the constructor, to make sure
         // that all constructors of all parent classes also use the overwritten sample
         // format.
-        streamUri.query[kUriSampleFormat] = "44100:16:2";
+        // We provide a sane default for the stream, but allow the user to be specific
+        // about an override.
+        streamUri.query[kUriSampleFormat] = streamUri.getQuery(kUriSampleFormat, "44100:16:2");
         stream = make_shared<LibrespotStream>(pcmListener_, ioc_, settings_, streamUri);
     }
     else if (streamUri.scheme == "airplay")


### PR DESCRIPTION
Allow the user to set a `sampleformat` for `librespot` streams, but provide the old stream-specific default of `44100:16:2`.

Adds a small snippet to the configuration documentation explaining how to set the sample rate to 24 bit for librespot.

Closes https://github.com/badaix/snapcast/issues/929