### PR TITLE
Disconnect from pulse temporarily while there are no chunks available

### DIFF
--- a/client/player/pulse_player.cpp
+++ b/client/player/pulse_player.cpp
@@ -199,6 +199,10 @@ void PulsePlayer::worker()
 
 void PulsePlayer::setHardwareVolume(double volume, bool muted)
 {
+    // if we're not connected to pulse, ignore the hardware volume change as the volume will be set upon reconnect
+    if (playstream_ == nullptr)
+        return;
+
     last_change_ = std::chrono::steady_clock::now();
     pa_cvolume cvolume;
     if (muted)
@@ -363,6 +367,7 @@ void PulsePlayer::start()
 
 void PulsePlayer::connect()
 {
+    std::lock_guard<std::mutex> lock(mutex_);
     LOG(INFO, LOG_TAG) << "Connecting to pulse\n";
 
     if (settings_.pcm_device.idx == -1)
@@ -511,6 +516,7 @@ void PulsePlayer::stop()
 
 void PulsePlayer::disconnect()
 {
+    std::lock_guard<std::mutex> lock(mutex_);
     LOG(INFO, LOG_TAG) << "Disconnecting from pulse\n";
 
     if (pa_ml_ != nullptr)

--- a/client/player/pulse_player.hpp
+++ b/client/player/pulse_player.hpp
@@ -52,6 +52,9 @@ protected:
     bool needsThread() const override;
     void worker() override;
 
+    void connect();
+    void disconnect();
+
     bool getHardwareVolume(double& volume, bool& muted) override;
     void setHardwareVolume(double volume, bool muted) override;
 
@@ -67,6 +70,8 @@ protected:
     std::chrono::microseconds latency_;
     int underflows_ = 0;
     std::atomic<int> pa_ready_;
+
+    long last_chunk_tick_;
 
     pa_buffer_attr bufattr_;
     pa_sample_spec pa_ss_;


### PR DESCRIPTION
Disconnect from pulseaudio when no chunk has been received for 5000 ms. (same as the alsa player).

When new chunks arrive, reconnect to pulseaudio and resume playing.

This enables the pulseaudio sink to go into an idle/suspended state for powersaving, and saves cpu cycles on the snapclient when no sound is being played.

Closes: https://github.com/badaix/snapcast/issues/927