### PR TITLE
New setting "streaming_client.initial_volume"

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -27,6 +27,7 @@ Within the `[stream]` section there are some global parameters valid for all `so
 - `chunk_ms`: Default source stream read chunk size [ms]. The server will continously read this number of milliseconds from the source into a buffer, before this buffer is passed to the encoder (the `codec` above)
 - `buffer`: Buffer [ms]. The end-to-end latency, from capturing a sample on the server until the sample is played-out on the client
 - `send_to_muted`: `true` or `false`: Send audio to clients that are muted
+- `initial_client_percent`: 0-100 [percent]: The volume an audio client gets assigned on very first connect (i.e. client not known to snapserver yet). Defaults to 100 if unset.
 
 `source` parameters have the form `key=value`, they are concatenated with an `&` character.
 Supported parameters for all source types:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -27,7 +27,6 @@ Within the `[stream]` section there are some global parameters valid for all `so
 - `chunk_ms`: Default source stream read chunk size [ms]. The server will continously read this number of milliseconds from the source into a buffer, before this buffer is passed to the encoder (the `codec` above)
 - `buffer`: Buffer [ms]. The end-to-end latency, from capturing a sample on the server until the sample is played-out on the client
 - `send_to_muted`: `true` or `false`: Send audio to clients that are muted
-- `initial_client_percent`: 0-100 [percent]: The volume an audio client gets assigned on very first connect (i.e. client not known to snapserver yet). Defaults to 100 if unset or invalid (e.g. out of bounds).
 
 `source` parameters have the form `key=value`, they are concatenated with an `&` character.
 Supported parameters for all source types:
@@ -269,3 +268,7 @@ meta:///<name of source#1>/<name of source#2>/.../<name of source#N>?name=<name>
 
 Plays audio from the active source with the highest priority, with `source#1` having the highest priority and `source#N` the lowest.  
 Use `codec=null` for stream sources that should only serve as input for meta streams
+
+## Streaming clients
+Streaming clients connect to the server and receive configuration and audio data. The client is fully controlled from the server so clients don't have to persist any state. The `[streaming_client]` section has just one option currently:
+- `initial_volume`: 0-100 [percent]: The volume a streaming client gets assigned on very first connect (i.e. the client is not known to the server yet). Defaults to 100 if unset.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -27,7 +27,7 @@ Within the `[stream]` section there are some global parameters valid for all `so
 - `chunk_ms`: Default source stream read chunk size [ms]. The server will continously read this number of milliseconds from the source into a buffer, before this buffer is passed to the encoder (the `codec` above)
 - `buffer`: Buffer [ms]. The end-to-end latency, from capturing a sample on the server until the sample is played-out on the client
 - `send_to_muted`: `true` or `false`: Send audio to clients that are muted
-- `initial_client_percent`: 0-100 [percent]: The volume an audio client gets assigned on very first connect (i.e. client not known to snapserver yet). Defaults to 100 if unset.
+- `initial_client_percent`: 0-100 [percent]: The volume an audio client gets assigned on very first connect (i.e. client not known to snapserver yet). Defaults to 100 if unset or invalid (e.g. out of bounds).
 
 `source` parameters have the form `key=value`, they are concatenated with an `&` character.
 Supported parameters for all source types:

--- a/server/etc/snapserver.conf
+++ b/server/etc/snapserver.conf
@@ -157,9 +157,13 @@ source = pipe:///tmp/snapfifo?name=default
 #send_to_muted = false
 #
 
+# Streaming client options ####################################################
+#
+[streaming_client]
+
 # Volume assigned to new snapclients [percent]
 # Defaults to 100 if unset
-#initial_client_percent = 100
+#initial_volume = 100
 #
 ###############################################################################
 

--- a/server/etc/snapserver.conf
+++ b/server/etc/snapserver.conf
@@ -156,6 +156,11 @@ source = pipe:///tmp/snapfifo?name=default
 # Send audio to muted clients
 #send_to_muted = false
 #
+
+# Volume assigned to new snapclients [percent]
+# Defaults to 100 if unset
+#initial_client_percent = 100
+#
 ###############################################################################
 
 

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -769,7 +769,7 @@ void Server::onMessageReceived(StreamSession* streamSession, const msg::BaseMess
         ClientInfoPtr client = group->getClient(streamSession->clientId);
         if (newGroup)
         {
-            client->config.volume.percent = settings_.stream.initialClientPercent;
+            client->config.volume.percent = settings_.streamingclient.initialVolume;
         }
 
         LOG(DEBUG, LOG_TAG) << "Sending ServerSettings to " << streamSession->clientId << "\n";

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -769,7 +769,7 @@ void Server::onMessageReceived(StreamSession* streamSession, const msg::BaseMess
         ClientInfoPtr client = group->getClient(streamSession->clientId);
         if (newGroup)
         {
-             client->config.volume.percent = settings_.stream.initialClientPercent;
+            client->config.volume.percent = settings_.stream.initialClientPercent;
         }
 
         LOG(DEBUG, LOG_TAG) << "Sending ServerSettings to " << streamSession->clientId << "\n";

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -767,6 +767,10 @@ void Server::onMessageReceived(StreamSession* streamSession, const msg::BaseMess
         }
 
         ClientInfoPtr client = group->getClient(streamSession->clientId);
+        if (newGroup)
+        {
+             client->config.volume.percent = settings_.stream.initialClientPercent;
+        }
 
         LOG(DEBUG, LOG_TAG) << "Sending ServerSettings to " << streamSession->clientId << "\n";
         auto serverSettings = make_shared<msg::ServerSettings>();

--- a/server/server_settings.hpp
+++ b/server/server_settings.hpp
@@ -63,7 +63,11 @@ struct ServerSettings
         size_t streamChunkMs{20};
         bool sendAudioToMutedClients{false};
         std::vector<std::string> bind_to_address{{"0.0.0.0"}};
-        uint16_t initialClientPercent{100};
+    };
+
+    struct StreamingClient
+    {
+        uint16_t initialVolume{100};
     };
 
     struct Logging
@@ -76,6 +80,7 @@ struct ServerSettings
     Http http;
     Tcp tcp;
     Stream stream;
+    StreamingClient streamingclient;
     Logging logging;
 };
 

--- a/server/server_settings.hpp
+++ b/server/server_settings.hpp
@@ -63,6 +63,7 @@ struct ServerSettings
         size_t streamChunkMs{20};
         bool sendAudioToMutedClients{false};
         std::vector<std::string> bind_to_address{{"0.0.0.0"}};
+        uint16_t initialClientPercent{100};
     };
 
     struct Logging

--- a/server/snapserver.cpp
+++ b/server/snapserver.cpp
@@ -117,8 +117,10 @@ int main(int argc, char* argv[])
         conf.add<Value<int>>("", "stream.buffer", "Buffer [ms]", settings.stream.bufferMs, &settings.stream.bufferMs);
         conf.add<Value<bool>>("", "stream.send_to_muted", "Send audio to muted clients", settings.stream.sendAudioToMutedClients,
                               &settings.stream.sendAudioToMutedClients);
-        conf.add<Value<uint16_t>>("", "stream.initial_client_percent", "Volume assigned to new snapclients", settings.stream.initialClientPercent,
-                                  &settings.stream.initialClientPercent);
+
+        // streaming_client options
+        conf.add<Value<uint16_t>>("", "streaming_client.initial_volume", "Volume [percent] assigned to new streaming clients", settings.streamingclient.initialVolume,
+                                  &settings.streamingclient.initialVolume);
 
         // logging settings
         conf.add<Value<string>>("", "logging.sink", "log sink [null,system,stdout,stderr,file:<filename>]", settings.logging.sink, &settings.logging.sink);

--- a/server/snapserver.cpp
+++ b/server/snapserver.cpp
@@ -117,7 +117,8 @@ int main(int argc, char* argv[])
         conf.add<Value<int>>("", "stream.buffer", "Buffer [ms]", settings.stream.bufferMs, &settings.stream.bufferMs);
         conf.add<Value<bool>>("", "stream.send_to_muted", "Send audio to muted clients", settings.stream.sendAudioToMutedClients,
                               &settings.stream.sendAudioToMutedClients);
-        conf.add<Value<uint16_t>>("","stream.initial_client_percent", "Volume assigned to new snapclients", settings.stream.initialClientPercent, &settings.stream.initialClientPercent);
+        conf.add<Value<uint16_t>>("", "stream.initial_client_percent", "Volume assigned to new snapclients", settings.stream.initialClientPercent,
+                                  &settings.stream.initialClientPercent);
 
         // logging settings
         conf.add<Value<string>>("", "logging.sink", "log sink [null,system,stdout,stderr,file:<filename>]", settings.logging.sink, &settings.logging.sink);

--- a/server/snapserver.cpp
+++ b/server/snapserver.cpp
@@ -117,6 +117,7 @@ int main(int argc, char* argv[])
         conf.add<Value<int>>("", "stream.buffer", "Buffer [ms]", settings.stream.bufferMs, &settings.stream.bufferMs);
         conf.add<Value<bool>>("", "stream.send_to_muted", "Send audio to muted clients", settings.stream.sendAudioToMutedClients,
                               &settings.stream.sendAudioToMutedClients);
+        conf.add<Value<uint16_t>>("","stream.initial_client_percent", "Volume assigned to new snapclients", settings.stream.initialClientPercent, &settings.stream.initialClientPercent);
 
         // logging settings
         conf.add<Value<string>>("", "logging.sink", "log sink [null,system,stdout,stderr,file:<filename>]", settings.logging.sink, &settings.logging.sink);


### PR DESCRIPTION
This resolves #910.

Testcases executed manually:

* Snapclient connects to snapserver for the first time: initial volume is 100 if not configured in `/etc/snapserver.conf` (identical to behaviour without this change). Volume is set to configured value when set. When configuration value is invalid, initial value is set to 100 too.
* Snapclient connects **not** for the first time (i.e. client already present in `/var/lib/snapserver/server.json`): Previous volume is unchanged.

Tested successfully both on current `master` and current `develop`.