### PR TITLE
Fix for Apple Silicon Compilation

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -77,8 +77,8 @@ OBJ      += ../common/daemon.o player/alsa_player.o browseZeroConf/browse_avahi.
 else ifeq ($(TARGET), MACOS)
 
 CXX       = g++
-CXXFLAGS += -DHAS_COREAUDIO -DHAS_VORBIS -DFREEBSD -DMACOS -DHAS_BONJOUR -DHAS_DAEMON -I/usr/local/include -Wno-unused-local-typedef -Wno-deprecated
-LDFLAGS  += -lvorbis -lFLAC -L/usr/local/lib -framework AudioToolbox -framework CoreAudio -framework CoreFoundation -framework IOKit
+CXXFLAGS += -DHAS_COREAUDIO -DHAS_VORBIS -DFREEBSD -DMACOS -DHAS_BONJOUR -DHAS_DAEMON -I/usr/local/include -I/opt/homebrew/include -Wno-unused-local-typedef -Wno-deprecated
+LDFLAGS  += -lvorbis -lFLAC -L/usr/local/lib -L/opt/homebrew/lib -framework AudioToolbox -framework CoreAudio -framework CoreFoundation -framework IOKit
 OBJ      += ../common/daemon.o player/coreaudio_player.o browseZeroConf/browse_bonjour.o
 
 else


### PR DESCRIPTION
Homebrew on modern Apple Silicon macOS now uses `/opt/homebrew` instead of `/usr/local/`.  This fixes compilation on macOS (tested on Monterey and Ventura beta 8).