### PR TITLE
(doc) Adapt mpv process example in player setup

### DIFF
--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -235,7 +235,11 @@ For example, you could install the minimalist **mpv** media player to pick up We
 
 ```ini
 [stream]
-source = process:///usr/bin/mpv?name=Webradio&sampleformat=48000:16:2&params=http://129.122.92.10:88/broadwavehigh.mp3 --no-terminal --audio-display=no --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm:file=/dev/stdout
+# mpv < 0.21.0
+#source = process:///usr/bin/mpv?name=Webradio&sampleformat=48000:16:2&params=http://129.122.92.10:88/broadwavehigh.mp3 --no-terminal --audio-display=no --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm:file=/dev/stdout
+# mpv >= 0.21.0
+source = process:///usr/bin/mpv?name=Webradio&sampleformat=48000:16:2&params=http://129.122.92.10:88/broadwavehigh.mp3 --no-terminal --audio-display=no --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm --ao-pcm-file=/dev/stdout
+
 ```
 
 ### Line-in


### PR DESCRIPTION
Cli flag was removed in newer mpv versions. Was already adapted in raw mpv example but not in process input one.

example given for process mpv produced
```
Option ao: this option does not accept sub-options.
Sub-options for --vo and --ao were removed from mpv in release 0.23.0.
See https://0x0.st/uM for details.
Error parsing option ao (option parameter could not be parsed)
Setting commandline option --ao=pcm:file=/dev/stdout failed.
```

Took us five minutes to figure this out, hope this safes others some time. :)
When changing saw that up in the file the explicit mpv example was already adapted.