### PR TITLE
server/control_session_http: update for boost 1.81.0

### DIFF
--- a/server/control_session_http.cpp
+++ b/server/control_session_http.cpp
@@ -127,8 +127,8 @@ boost::beast::string_view mime_type(boost::beast::string_view path)
 std::string path_cat(boost::beast::string_view base, boost::beast::string_view path)
 {
     if (base.empty())
-        return path.to_string();
-    std::string result = base.to_string();
+        return static_cast<std::string>(path);
+    std::string result = static_cast<std::string>(base);
     char constexpr path_separator = '/';
     if (result.back() == path_separator)
         result.resize(result.size() - 1);
@@ -171,7 +171,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
         res.set(http::field::server, HTTP_SERVER_NAME);
         res.set(http::field::content_type, "text/html");
         res.keep_alive(req.keep_alive());
-        res.body() = why.to_string();
+        res.body() = static_cast<std::string>(why);
         res.prepare_payload();
         return res;
     };
@@ -182,7 +182,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
         res.set(http::field::server, HTTP_SERVER_NAME);
         res.set(http::field::content_type, "text/html");
         res.keep_alive(req.keep_alive());
-        res.body() = "The resource '" + target.to_string() + "' was not found.";
+        res.body() = "The resource '" + static_cast<std::string>(target) + "' was not found.";
         res.prepare_payload();
         return res;
     };
@@ -204,7 +204,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
         res.set(http::field::server, HTTP_SERVER_NAME);
         res.set(http::field::content_type, "text/html");
         res.keep_alive(req.keep_alive());
-        res.body() = "An error occurred: '" + what.to_string() + "'";
+        res.body() = "An error occurred: '" + static_cast<std::string>(what) + "'";
         res.prepare_payload();
         return res;
     };


### PR DESCRIPTION
- Fixes #1082 

Boost 1.81.0 have moved to the std::string_view and to_string() has been deprecated. This replaces the to_string with a static_cast to std::string.

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>