### PR TITLE
 Fix "unqualified call to std::move" warning

### DIFF
--- a/server/streamreader/tcp_stream.cpp
+++ b/server/streamreader/tcp_stream.cpp
@@ -79,7 +79,7 @@ void TcpStream::do_connect()
             if (!ec)
             {
                 LOG(DEBUG, LOG_TAG) << "New client connection\n";
-                stream_ = make_unique<tcp::socket>(move(socket));
+                stream_ = make_unique<tcp::socket>(std::move(socket));
                 on_connect();
             }
             else


### PR DESCRIPTION
This removes the warning when using [-Wunqualified-std-cast-call].
