### PR TITLE
Fix build with GCC 13

### DIFF
--- a/common/sample_format.hpp
+++ b/common/sample_format.hpp
@@ -19,6 +19,7 @@
 #ifndef SAMPLE_FORMAT_H
 #define SAMPLE_FORMAT_H
 
+#include <cstdint>
 #include <string>
 
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/894742