### PR TITLE
Added more `fs.protected_fifos` to player_setup and configuration

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -51,7 +51,7 @@ pipe:///<path/to/pipe>?name=<name>[&mode=create][&dryout_ms=2000]
 
 `mode` can be `create` or `read`. Sometimes your audio source might insist in creating the pipe itself. So the pipe creation mode can by changed to "not create, but only read mode", using the `mode` option set to `read`
 
-**NOTE** With newer kernels using FIFO pipes in a global sticky folder (e.g. `/tmp`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
+**NOTE** With newer kernels using FIFO pipes in a world writeable sticky dir (e.g. `/tmp`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
 
 See [stackexchange](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for more details. You need to run this after each reboot or add it to /etc/sysctl.conf or /etc/sysctl.d/50-default.conf depending on distribution.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -51,10 +51,9 @@ pipe:///<path/to/pipe>?name=<name>[&mode=create][&dryout_ms=2000]
 
 `mode` can be `create` or `read`. Sometimes your audio source might insist in creating the pipe itself. So the pipe creation mode can by changed to "not create, but only read mode", using the `mode` option set to `read`
 
-With newer kernels one might also have to change this sysctl-setting, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`
+**NOTE** With newer kernels using FIFO pipes in a global sticky folder (e.g. `/tmp`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
 
 See [stackexchange](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for more details. You need to run this after each reboot or add it to /etc/sysctl.conf or /etc/sysctl.d/50-default.conf depending on distribution.
-
 
 ### librespot
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -51,6 +51,11 @@ pipe:///<path/to/pipe>?name=<name>[&mode=create][&dryout_ms=2000]
 
 `mode` can be `create` or `read`. Sometimes your audio source might insist in creating the pipe itself. So the pipe creation mode can by changed to "not create, but only read mode", using the `mode` option set to `read`
 
+With newer kernels one might also have to change this sysctl-setting, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`
+
+See [stackexchange](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for more details. You need to run this after each reboot or add it to /etc/sysctl.conf or /etc/sysctl.d/50-default.conf depending on distribution.
+
+
 ### librespot
 
 Launches librespot and reads audio from stdout

--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -9,7 +9,7 @@ The goal is to build the following chain:
 audio player software -> snapfifo -> snapserver -> network -> snapclient -> alsa
 ```
 
-**NOTE** With newer kernels using FIFO pipes (e.g. `/tmp/snapfifo`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
+**NOTE** With newer kernels using FIFO pipes in a world writeable sticky dir (e.g. `/tmp`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
 
 See [stackexchange](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for more details. You need to run this after each reboot or add it to /etc/sysctl.conf or /etc/sysctl.d/50-default.conf depending on distribution.
 

--- a/doc/player_setup.md
+++ b/doc/player_setup.md
@@ -9,6 +9,10 @@ The goal is to build the following chain:
 audio player software -> snapfifo -> snapserver -> network -> snapclient -> alsa
 ```
 
+**NOTE** With newer kernels using FIFO pipes (e.g. `/tmp/snapfifo`) one might also have to turn off `fs.protected_fifos`, as default settings have changed recently: `sudo sysctl fs.protected_fifos=0`. 
+
+See [stackexchange](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for more details. You need to run this after each reboot or add it to /etc/sysctl.conf or /etc/sysctl.d/50-default.conf depending on distribution.
+
 ## Streams
 
 Snapserver can read audio from several sources, which are configured in the `snapserver.conf` file (default location is `/etc/snapserver.conf`); the config file can be changed with the `-c` parameter.  


### PR DESCRIPTION
Originally information on `fs.protected_fifos` setting was only in the Mopidy setup section, however I was trying to use fifos with ffmpeg. Took me a lot of searching elsewhere on the internet before I found the issue, and then realized it was mentioned in the Mopidy section.

I've added information on it to the top of the configuration, and in the pipes section in player_setup to hopefully make it more obvious to others.