### PR TITLE
Initialize pulse latency to sane values

### DIFF
--- a/client/player/pulse_player.cpp
+++ b/client/player/pulse_player.cpp
@@ -349,8 +349,8 @@ void PulsePlayer::stateCallback(pa_context* ctx)
 
 void PulsePlayer::writeCallback(pa_stream* stream, size_t nbytes)
 {
-    pa_usec_t usec;
-    int neg;
+    pa_usec_t usec = 0;
+    int neg = 0;
     pa_stream_get_latency(stream, &usec, &neg);
 
     auto numFrames = nbytes / stream_->getFormat().frameSize();


### PR DESCRIPTION
pa_stream_get_latency usually fails immediately after (re-)connecting to PulseAudio, in which case the number in usec is a (possibly huge) random value. This change initializes the `usec` and `neg` variables to sane values.