### PR TITLE
Autoconnect ports once after connecting to Jack server

### DIFF
--- a/server/streamreader/jack_stream.cpp
+++ b/server/streamreader/jack_stream.cpp
@@ -207,6 +207,11 @@ void JackStream::tryConnect()
             wait(read_timer_, 5s, [this] { tryConnect(); });
             return;
         }
+
+        if (doAutoConnect_)
+        {
+            autoConnectPorts();
+        }
     }
     catch (exception& e)
     {


### PR DESCRIPTION
Small bugfix/addition to the Jack streamreader: if automatic connection of Jack ports is configured,
make sure to execute the autoconnect once after a successful connection to the Jack server. 