### PR TITLE
RFC: Add method to pass arbitrary client system info

### DIFF
--- a/client/client_settings.hpp
+++ b/client/client_settings.hpp
@@ -24,6 +24,7 @@
 
 // standard headers
 #include <string>
+#include <chrono>
 
 
 
@@ -73,10 +74,24 @@ struct ClientSettings
         std::string filter{"*:info"};
     };
 
+    struct SystemInfo
+    {
+        enum class Mode
+        {
+            file,
+            script,
+            none
+        };
+        Mode mode{Mode::none};
+        std::string path;
+        int interval_secs;
+    };
+
     size_t instance{1};
     std::string host_id;
 
     Server server;
     Player player;
     Logging logging;
+    SystemInfo systemInfo;
 };

--- a/client/controller.hpp
+++ b/client/controller.hpp
@@ -59,9 +59,12 @@ private:
 
     void getNextMessage();
     void sendTimeSyncMessage(int quick_syncs);
+    void sendSystemInfoMessage();
+    json getSystemInfo();
 
     boost::asio::io_context& io_context_;
     boost::asio::steady_timer timer_;
+    boost::asio::steady_timer systemInfoTimer_;
     ClientSettings settings_;
     SampleFormat sampleFormat_;
     std::unique_ptr<ClientConnection> clientConnection_;

--- a/common/message/client_system_info.hpp
+++ b/common/message/client_system_info.hpp
@@ -1,0 +1,45 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2022  Johannes Pohl
+    Copyright (C) 2024  Marcus Weseloh
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#ifndef MESSAGE_CLIENT_SYSTEM_INFO_HPP
+#define MESSAGE_CLIENT_SYSTEM_INFO_HPP
+
+// local headers
+#include "json_message.hpp"
+
+
+namespace msg
+{
+
+// Client system information sent from client to server.
+// This message can contrain arbitrary JSON data.
+class ClientSystemInfo : public JsonMessage
+{
+public:
+    ClientSystemInfo() : JsonMessage(message_type::kClientSystemInfo)
+    {
+    }
+
+    ~ClientSystemInfo() override = default;
+};
+} // namespace msg
+
+
+#endif
+

--- a/common/message/factory.hpp
+++ b/common/message/factory.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 // local headers
+#include "client_system_info.hpp"
 #include "client_info.hpp"
 #include "codec_header.hpp"
 #include "hello.hpp"
@@ -76,6 +77,8 @@ static std::unique_ptr<BaseMessage> createMessage(const BaseMessage& base_messag
             return createMessage<PcmChunk>(base_message, buffer);
         case message_type::kClientInfo:
             return createMessage<ClientInfo>(base_message, buffer);
+        case message_type::kClientSystemInfo:
+            return createMessage<ClientSystemInfo>(base_message, buffer);
         default:
             return nullptr;
     }

--- a/common/message/message.hpp
+++ b/common/message/message.hpp
@@ -63,9 +63,10 @@ enum class message_type : uint16_t
     kHello = 5,
     // kStreamTags = 6,
     kClientInfo = 7,
+    kClientSystemInfo = 8,
 
     kFirst = kBase,
-    kLast = kClientInfo
+    kLast = kClientSystemInfo
 };
 
 static std::ostream& operator<<(std::ostream& os, const message_type& msg_type)
@@ -92,6 +93,9 @@ static std::ostream& operator<<(std::ostream& os, const message_type& msg_type)
             break;
         case message_type::kClientInfo:
             os << "ClientInfo";
+            break;
+        case message_type::kClientSystemInfo:
+            os << "ClientSystemInfo";
             break;
         default:
             os << "Unknown";

--- a/server/config.hpp
+++ b/server/config.hpp
@@ -235,6 +235,10 @@ struct ClientInfo
         lastSeen.tv_sec = jGet<int32_t>(j["lastSeen"], "sec", 0);
         lastSeen.tv_usec = jGet<int32_t>(j["lastSeen"], "usec", 0);
         connected = jGet<bool>(j, "connected", true);
+        if (j.contains("systemInfo"))
+        {
+            systemInfo = j["systemInfo"].template get<json>();
+        }
     }
 
     json toJson()
@@ -247,6 +251,7 @@ struct ClientInfo
         j["lastSeen"]["sec"] = lastSeen.tv_sec;
         j["lastSeen"]["usec"] = lastSeen.tv_usec;
         j["connected"] = connected;
+        j["systemInfo"] = systemInfo;
         return j;
     }
 
@@ -256,6 +261,7 @@ struct ClientInfo
     ClientConfig config;
     timeval lastSeen;
     bool connected;
+    json systemInfo;
 };
 
 

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -22,6 +22,7 @@
 // local headers
 #include "common/aixlog.hpp"
 #include "common/message/client_info.hpp"
+#include "common/message/client_system_info.hpp"
 #include "common/message/hello.hpp"
 #include "common/message/server_settings.hpp"
 #include "common/message/time.hpp"
@@ -761,6 +762,22 @@ void Server::onMessageReceived(StreamSession* streamSession, const msg::BaseMess
         clientInfo->config.volume.muted = infoMsg.isMuted();
         jsonrpcpp::notification_ptr notification = make_shared<jsonrpcpp::Notification>(
             "Client.OnVolumeChanged", jsonrpcpp::Parameter("id", streamSession->clientId, "volume", clientInfo->config.volume.toJson()));
+        controlServer_->send(notification->to_json().dump());
+    }
+    else if (baseMessage.type == message_type::kClientSystemInfo)
+    {
+        ClientInfoPtr clientInfo = Config::instance().getClientInfo(streamSession->clientId);
+        if (clientInfo == nullptr)
+        {
+            LOG(ERROR, LOG_TAG) << "client not found: " << streamSession->clientId << "\n";
+            return;
+        }
+        msg::ClientSystemInfo sysInfoMsg;
+        sysInfoMsg.deserialize(baseMessage, buffer);
+
+        clientInfo->systemInfo = sysInfoMsg.msg;
+        jsonrpcpp::notification_ptr notification = make_shared<jsonrpcpp::Notification>(
+            "Client.OnSystemInfoChanged", jsonrpcpp::Parameter("id", streamSession->clientId, "systemInfo", clientInfo->systemInfo));
         controlServer_->send(notification->to_json().dump());
     }
     else if (baseMessage.type == message_type::kHello)


### PR DESCRIPTION
This is a request-for-comments PR regarding a new feature I would like to add to SnapCast: sending arbitrary system information from SnapCast clients to the server, so that the information can be displayed in SnapWeb.

It adds two new command-line switches to the client:
- `--sysinfo [file:<path to JSON file>, script:<path to executable returning JSON>]`
- `--sysinfo-interval [seconds - interval in seconds between system information updates]`

Any JSON values that are in the specified file or returned by the script will be passed to the SnapCast server. The server then returns this information along with the other client info and also sends an `Client.OnSystemInfoChanged` event via the Websocket.

The data is displayed in a dialog similar to the client details. An example implementation for SnapWeb can be found in this branch: https://github.com/mawe42/snapweb/tree/show-system-info

Use-case for this feature is that I want to sent and display information about the battery charge of the connected clients., but possibly also other information.

The question here is: would this be something that you would consider for integration in SnapCast?