### PR TITLE
Attempt to discover a new server over mdns if the previous one is down

### DIFF
--- a/client/client_settings.hpp
+++ b/client/client_settings.hpp
@@ -54,6 +54,12 @@ struct ClientSettings
     {
         std::string host{""};
         size_t port{1704};
+#if defined(HAS_AVAHI) || defined(HAS_BONJOUR)
+        bool use_mdns{true};
+#else
+        bool use_mdns{false};
+#endif
+        ssize_t connection_attempts{-1};
     };
 
     struct Player

--- a/client/controller.hpp
+++ b/client/controller.hpp
@@ -71,4 +71,6 @@ private:
     // std::unique_ptr<MetadataAdapter> meta_;
     std::unique_ptr<msg::ServerSettings> serverSettings_;
     std::unique_ptr<msg::CodecHeader> headerChunk_;
+
+    ssize_t connectionAttempts_;
 };


### PR DESCRIPTION
Hello,
I run snapserver on a docker swarm and I've noticed that whenever the server instance gets migrated from one node to the other, snapclient doesn't try to discover the new server.
My proposed solution to this is to add a number of connection attempts after which snapclient tries to find a new server through mdns.

I added two arguments:
* --connection-attempts (defaults to `-1`)
controls how many times snapclient should try to reconnect before trying to discover a new server.
* --mdns (defaults to `true`)
controls whether mdns should be used or not

