### PR TITLE
Lazily load streams in meta streams

### DIFF
--- a/server/streamreader/meta_stream.cpp
+++ b/server/streamreader/meta_stream.cpp
@@ -56,7 +56,7 @@ bool MetaStream::isAllowed(const PcmStream& stream) const
         if (component.empty())
             continue;
 
-        if (stream.getName() == component)
+        if (component == WILDCARD || stream.getName() == component)
         {
             return true;
         }
@@ -98,6 +98,8 @@ void MetaStream::updateActiveStream()
             if (component == first->getName())
                 return true;
             if (component == second->getName())
+                return false;
+            if (component == WILDCARD)
                 return false;
         }
         return false;

--- a/server/streamreader/meta_stream.hpp
+++ b/server/streamreader/meta_stream.hpp
@@ -49,6 +49,9 @@ public:
     void start() override;
     void stop() override;
 
+    void addStream(std::shared_ptr<PcmStream> stream);
+    void removeStream(const PcmStream& stream);
+
     // Setter for properties
     void setShuffle(bool shuffle, ResultHandler handler) override;
     void setLoopStatus(LoopStatus status, ResultHandler handler) override;
@@ -67,6 +70,9 @@ public:
     void play(ResultHandler handler) override;
 
 protected:
+    bool isAllowed(const PcmStream& stream) const;
+    void updateActiveStream();
+
     /// Implementation of PcmStream::Listener
     void onPropertiesChanged(const PcmStream* pcmStream, const Properties& properties) override;
     void onStateChanged(const PcmStream* pcmStream, ReaderState state) override;

--- a/server/streamreader/meta_stream.hpp
+++ b/server/streamreader/meta_stream.hpp
@@ -41,6 +41,9 @@ namespace streamreader
 class MetaStream : public PcmStream, public PcmStream::Listener
 {
 public:
+    static inline const std::string WILDCARD = "*";
+
+public:
     /// ctor. Encoded PCM data is passed to the PcmStream::Listener
     MetaStream(PcmStream::Listener* pcmListener, const std::vector<std::shared_ptr<PcmStream>>& streams, boost::asio::io_context& ioc,
                const ServerSettings& server_settings, const StreamUri& uri);

--- a/server/streamreader/stream_manager.cpp
+++ b/server/streamreader/stream_manager.cpp
@@ -146,6 +146,9 @@ PcmStreamPtr StreamManager::addStream(StreamUri& streamUri)
         {
             if (s->getName() == stream->getName())
                 throw SnapException("Stream with name \"" + stream->getName() + "\" already exists");
+
+            if (auto meta = dynamic_cast<MetaStream*>(s.get()))
+                meta->addStream(stream);
         }
         streams_.push_back(stream);
     }
@@ -161,6 +164,12 @@ void StreamManager::removeStream(const std::string& name)
     {
         (*iter)->stop();
         streams_.erase(iter);
+
+        for (const auto& s : streams_)
+        {
+            if (auto meta = dynamic_cast<MetaStream*>(s.get()))
+                meta->removeStream(**iter);
+        }
     }
 }
 


### PR DESCRIPTION
## Prior
As discussed in https://github.com/badaix/snapcast/issues/821, PipeWire can now automatically discover PipeWire server instances and register a new TCP stream to it. This works, but if you are using meta streams, it will be created outside of it, and it's currently not possible to do otherwise. 

This is because meta streams are built at startup from their definition specified in the configuration file, and at startup, the pipewire stream does not yet exist, and so cannot be added.

In other words, this currently fail:
```
source = pipe:///tmp/snapfifo?name=default
source = meta:///default/PipeWire-Jerome-PC?name=meta
```

because `PipeWire-Jerome-PC` does not exist at startup. 

## Fix
- Meta stream can now be created empty.
- Meta stream sources are lazily created.
    - If a source in the meta's config does not exist at startup, it will only be added when created.
- Bonus: Add a catch-all wildcard operator to meta streams. Example:
```
source = pipe:///tmp/snapfifo?name=default
source = spotify:///librespot?name=Spotify
# The meta stream will include Spotify, default, and any stream created later on.
# Spotify will be prioritized, then other streams in creation order.
source = meta:///Spotify/*?name=meta
```
This is in its own commit and can easily be removed if you disagree.

What does not change:
Everything else:
- If a source exists at startup, the behaviour is the same.
- A source not specified in a meta stream config file will never get added to it.
- The same ordering behaviour applies. Example:
```
source = pipe:///tmp/snapfifo?name=default
# At startup, default will be the active stream, but if `PipeWire-Jerome-PC` ever get created, it will take priority.
source = meta:///PipeWire-Jerome-PC/default?name=meta
```

I think this PR partly fixes https://github.com/badaix/snapcast/issues/1232 when PipeWire is used.

## Pull Request Checklist
- [x] Done
