### PR TITLE
new style resolver and connect - fixes build with boost 1.87.0

### DIFF
--- a/client/player/player.cpp
+++ b/client/player/player.cpp
@@ -34,10 +34,10 @@
 #pragma GCC diagnostic ignored "-Wmissing-braces"
 #pragma GCC diagnostic ignored "-Wnarrowing"
 #pragma GCC diagnostic ignored "-Wc++11-narrowing"
-#include <boost/process/args.hpp>
-#include <boost/process/async.hpp>
-#include <boost/process/child.hpp>
-#include <boost/process/exe.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/exe.hpp>
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
- closes #1307
- additionally cleans up warnings
  - [call v1 boost headers fixing deprecated warning](https://github.com/badaix/snapcast/commit/431adc09670b47ed7dbdf0f0ed8c633a08ce4022)