### PR TITLE
Edit the CI process to build deb packages also for 32-bit Debian

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,6 +53,7 @@ jobs:
           - amd64
           - armhf
           - arm64
+          - i386
         include:
           - arch: "amd64"
             os: ubuntu-latest
@@ -63,6 +64,9 @@ jobs:
           - arch: "arm64"
             os: self-hosted-rpi5
             image_prefix: "badaix/raspios-lite:"
+          - arch: "i386"
+            os: ubuntu-latest
+            image_prefix: "debian:"
 
     runs-on: ${{ matrix.os }}
     name: deb (${{ matrix.arch }}, ${{ matrix.debian }})
@@ -72,7 +76,7 @@ jobs:
       image: ${{matrix.image_prefix}}${{matrix.debian}}
     steps:
       - name: Get dependencies
-        run: apt-get update && apt-get install -yq wget debhelper build-essential cmake git rename libatomic1 libasound2-dev libsoxr-dev libvorbisidec-dev libvorbis-dev libflac-dev libopus-dev alsa-utils libpulse-dev libavahi-client-dev avahi-daemon libexpat1-dev python3 ccache unzip
+        run: apt-get update && apt-get install -yq wget debhelper build-essential cmake git rename libatomic1 libasound2-dev libsoxr-dev libvorbisidec-dev libvorbis-dev libflac-dev libopus-dev alsa-utils libpulse-dev libavahi-client-dev avahi-daemon libexpat1-dev python3 ccache unzip gcc-multilib g++-multilib
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Get GitHub cli
@@ -285,4 +289,3 @@ jobs:
   #     with:
   #       name: snapcast_${{ matrix.arch }}-fedora-${{matrix.image}}-${{ github.sha }}
   #       path: ~/rpmbuild/RPMS/${{ matrix.arch }}/snap*.rpm
-

--- a/extras/package/debian/control
+++ b/extras/package/debian/control
@@ -10,7 +10,9 @@ Build-Depends: debhelper (>= 10~),
                libopus-dev,
                libavahi-client-dev,
                libasio-dev,
-               libsoxr-dev
+               libsoxr-dev,
+               gcc-multilib,
+               g++-multilib
 Standards-Version: 4.1.4
 Homepage: https://github.com/badaix/snapcast
 Vcs-Git: https://github.com/badaix/snapcast.git


### PR DESCRIPTION
Add support for building deb packages for 32-bit Debian in the CI process.

* **extras/package/debian/control**
  - Add `gcc-multilib` and `g++-multilib` to `Build-Depends` for `i386` architecture.

* **.github/workflows/package.yml**
  - Add `i386` to the `arch` matrix in the `deb` job.
  - Update `run` commands in the `deb` job to install dependencies for `i386` architecture.

