### PR TITLE
Add back restricted Stream.AddStream functionality

### DIFF
--- a/doc/json_rpc_api/control.md
+++ b/doc/json_rpc_api/control.md
@@ -485,7 +485,7 @@ See [Plugin.Stream.Player.SetProperty](stream_plugin.md#pluginstreamplayersetpro
 ### Stream.AddStream
 
 Note: for security purposes, we don't allow adding `process` streams.
-We also don't allow setting the `controlscript` parameter.
+We also don't allow setting the `controlscript` query parameter of streamUri.
 
 #### Request
 

--- a/doc/json_rpc_api/control.md
+++ b/doc/json_rpc_api/control.md
@@ -511,6 +511,7 @@ We also don't allow setting the `controlscript` query parameter of streamUri.
 
 ```json
 {"id":8,"jsonrpc":"2.0","result":{"stream_id":"stream 2"}}
+```
 
 
 ##### Error

--- a/doc/json_rpc_api/control.md
+++ b/doc/json_rpc_api/control.md
@@ -161,6 +161,8 @@ The Server JSON object contains a list of Groups and Streams. Every Group holds 
 * Stream
   * [Stream.Control](#streamcontrol)
   * [Stream.SetProperty](#streamsetproperty)
+  * [Stream.AddStream](#streamaddstream)
+  * [Stream.RemoveStream](#streamremovestream)
 
 ### Notifications
 
@@ -479,6 +481,37 @@ See [Plugin.Stream.Player.SetProperty](stream_plugin.md#pluginstreamplayersetpro
 ```json
 {"id": 1, "jsonrpc": "2.0", "result": "ok"}
 ```
+
+### Stream.AddStream
+
+Note: for security purposes, we don't allow adding `process` streams.
+We also don't allow setting the `controlscript` parameter.
+
+#### Request
+
+```json
+{"id":8,"jsonrpc":"2.0","method":"Stream.AddStream","params":{"streamUri":"pipe:///tmp/snapfifo?name=stream 2"}}
+```
+
+#### Response
+
+```json
+{"id":8,"jsonrpc":"2.0","result":{"stream_id":"stream 2"}}
+```
+
+### Stream.RemoveStream
+
+#### Request
+
+```json
+{"id":8,"jsonrpc":"2.0","method":"Stream.RemoveStream","params":{"id":"stream 2"}}
+```
+
+#### Response
+
+```json
+{"id":8,"jsonrpc":"2.0","result":{"stream_id":"stream 2"}}
+
 
 ##### Error
 

--- a/server/control_requests.cpp
+++ b/server/control_requests.cpp
@@ -702,11 +702,13 @@ void StreamAddRequest::execute(const jsonrpcpp::request_ptr& request, AuthInfo& 
 
     // Don't allow adding a process stream: CVE-2023-36177
     const std::string streamUri = request->params().get("streamUri");
-    if(StreamUri(streamUri).scheme == "process")
+    const StreamUri parsedUri(streamUri);
+    if(parsedUri.scheme == "process")
         throw jsonrpcpp::InvalidParamsException("Adding process streams is not allowed", request->id());
     
-    // Don't allow settings the controlscript parameter
-    checkParamsNotAllowed(request, {"controlscript"});
+    // Don't allow settings the controlscript streamUri property
+    if (!parsedUri.getQuery("controlscript").empty())
+        throw jsonrpcpp::InvalidParamsException("No controlscript streamUri property allowed", request->id());
 
     std::ignore = authinfo;
     LOG(INFO, LOG_TAG) << "Stream.AddStream(" << request->params().get("streamUri") << ")\n";

--- a/server/control_requests.cpp
+++ b/server/control_requests.cpp
@@ -44,16 +44,6 @@ static void checkParams(const jsonrpcpp::request_ptr& request, const std::vector
     }
 }
 
-/// throw InvalidParamsException if one of @p params exists in @p request
-static void checkParamsNotAllowed(const jsonrpcpp::request_ptr& request, const std::vector<std::string>& params)
-{
-    for (const auto& param : params)
-    {
-        if (request->params().has(param))
-            throw jsonrpcpp::InvalidParamsException("Parameter '" + param + "' is not allowed", request->id());
-    }
-}
-
 
 Request::Request(const Server& server, const std::string& method) : server_(server), method_(method)
 {


### PR DESCRIPTION
This pull requests adds back Stream.AddStream and Stream.AddStream and Stream.RemoveStream after they were removed due to CVE-2023-36177.

The Stream.StartStream is restricted to be more secure:
* we don't allow to start _process_ streams
* we don't allow the _controlscript_ parameter