### PR TITLE
Ensure Immediate Stream Flush for Logging in aixlog

### DIFF
--- a/common/aixlog.hpp
+++ b/common/aixlog.hpp
@@ -771,6 +771,7 @@ protected:
             else
                 stream << result << " " << message << "\n";
         }
+         stream.flush();
     }
 
     std::string format_;


### PR DESCRIPTION
### PR Description: Ensure Immediate Stream Flush for Logging in `aixlog`

#### Problem:
Certain tools, such as Python's `subprocess` library, that capture the `stdout` of a running program experience delayed output. This occurs because log messages remain in the buffer and are only written out when the process stops.

#### Solution:
This PR introduces a small but critical update to the `SinkFormat` structure in the `common/aixlog.hpp` file. The modification ensures that the stream is explicitly flushed after each log message, guaranteeing immediate output delivery. 

#### Changes Made:
* [`common/aixlog.hpp`](diffhunk://#diff-0b26a46048461cb3c3b3c912d2fe1203e8d9392a56ea25b255e3e333d9b860fbR774): Added a call to `stream.flush()` after writing the log message to ensure the stream is flushed.


#### Impact:
This fix ensures that log messages are promptly written to the stream, enhancing compatibility with tools that rely on real-time output processing.

* * *

## Pull Request Checklist

* Contributions must be licensed under the [GPL-3.0 License](LICENSE)

* This project loosely follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)

* For better compatibility with embedded toolchains, the used C++ standard should be limited to C++17

* Code should be formatted by running `make reformat`

* Branch from the `develop` branch and ensure it is up to date with the current `develop` branch before submitting your pull request. If it doesn't merge cleanly with `develop`, you may be asked to resolve the conflicts. Pull requests to master will be closed.

* Commits should be as small as possible while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).

* Pull requests must not contain compiled sources (already set by the default .gitignore) or binary files

* Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests. If tested manually, provide information about the test scope in the PR description (e.g. “Test passed: Upgrade version from 0.42 to 0.42.23.”).

* Create _Work In Progress [WIP]_ pull requests only if you need clarification or an explicit review before you can continue your work item.

* If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review by contacting us via [email](mailto:snapcast@badaix.de).

* Post review:
  * If a review requires you to change your commit(s), please test the changes again.
  * Amend the affected commit(s) and force push onto your branch.
  * Set respective comments in your GitHub review to resolved.
  * Create a general PR comment to notify the reviewers that your amendments are ready for another round of review.
