### PR TITLE
Fix some typos in streamreader README

### DIFF
--- a/server/streamreader/README.meta
+++ b/server/streamreader/README.meta
@@ -1,21 +1,21 @@
 Metadata tags
 =============
 The metatag interface will propegate anything to the client, ie no restrictions on the tags.
-But, to avoid total confusion in the tag display app (like Kodi), we need some groundrules.
+But, to avoid total confusion in the tag display app (like Kodi), we need some ground rules.
 
 My suggestion is to stick with the Vorbis standard as described in:
 
 	http://www.xiph.org/vorbis/doc/v-comment.html
 	https://wiki.xiph.org/Field_names
 
-In addition we should accept unique identifiers of the stream such as Spotify track ID or 
+In addition we should accept unique identifiers of the stream such as Spotify track ID or
 MusicBrainz id which can be used to lookup additional information online.
 
 Example:
 	ARTIST: Pink Floyd
 	ALBUM: Dark Side of the Moon
 	TITLE: Money
-	METADATA_BLOCK_PICTURE: base64 (https://xiph.org/flac/format.html#metadata_block_picture) 
+	METADATA_BLOCK_PICTURE: base64 (https://xiph.org/flac/format.html#metadata_block_picture)
 
 
 Parsing tags from streams
@@ -25,9 +25,9 @@ track title I added a patch 'librespot-meta.patch' to apply to get artist/title.
 
 TBH, the meta tag output from players are a mess, neither Librespot nor Shairport-sync associate
 metadata with their audio interfaces, ie they don't even export metadata when the audio interface
-supports it, at least Shairport-sync exports a ritch set of data. 
+supports it, at least Shairport-sync exports a rich set of data.
 
-So, to get artist/album apply the patch to librespot and recompile, otherwise you will only get the 
+So, to get artist/album apply the patch to librespot and recompile, otherwise you will only get the
 track title.
 
 Or, you can build librespot from https://github.com/frafall/librespot.git


### PR DESCRIPTION
Just another documentation typo fix.