### PR TITLE
Rename deb package with-pulse in control file

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -138,6 +138,15 @@ jobs:
           fakeroot make -f debian/rules CMAKEFLAGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBOOST_ROOT=$GITHUB_WORKSPACE/${{env.BOOST}} -DCMAKE_BUILD_TYPE:STRING=Release -DREVISION=${{ github.sha }} -DBUILD_WITH_PULSE=ON -DSNAPWEB_DIR:STRING=$GITHUB_WORKSPACE/snapweb" binary
           rm ../snapserver_*_${{ matrix.arch }}.deb
           rename 's/_${{ matrix.arch }}/_${{ matrix.arch }}_${{ matrix.debian }}_with-pulse/g' ../snap*_${{ matrix.arch }}.deb
+          deb_file="../snapclient_${{ matrix.arch }}_${{ matrix.debian }}_with-pulse.deb"
+          mkdir ../debtmp
+          dpkg-deb -R "$deb_file" ../debtmp
+          sed -i "s|Package: snapclient|Package: snapclient-with-pulse|g" ../debtmp/DEBIAN/control
+          cd ../debtmp/
+          find . -type f -not -path "./DEBIAN/*" -exec md5sum {} + | sort -k 2 | sed 's/\.\/\(.*\)/\1/' > DEBIAN/md5sums
+          cd .. || exit 0
+          dpkg-deb -b ../debtmp "$deb_file"
+          rm -rf ../debtmp
       - name: Release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Renamed deb package with-pulse in control file to distinguish it from the package without pulse, to keep it from being overwritten with the package without pulse during apt update.

I'm not sure how to test this, but it's working in a bash shell script i use for my own repo.

What happens since they both are named the same, is that if you have with-pulse installed, and a new release is published, it will be replaced with the one without pulse, which will of course render it broken.

This is with both packages available in the repo. 

Currently i don't see both version in the debian apt repo, so i added both to [my repo](https://github.com/tmiland/deb.tmiland.com). 
This is the output:

```bash
apt pol "snapclient*"
snapclient-with-pulse:
  Installed: 0.31.0-1
  Candidate: 0.32.1-1
  Version table:
     0.32.1-1 600
        600 https://deb.tmiland.com/debian ./ Packages
 *** 0.31.0-1 600
        600 https://deb.tmiland.com/debian ./ Packages
        100 /var/lib/dpkg/status
snapclient:
  Installed: (none)
  Candidate: 0.32.1-1
  Version table:
     0.32.1-1 600
        600 https://deb.tmiland.com/debian ./ Packages
     0.31.0-1 -1000
       -1000 https://deb.debian.org/debian unstable/main amd64 Packages
     0.31.0-1 600
        600 https://deb.tmiland.com/debian ./ Packages
     0.31.0-1 -1
        100 /var/lib/dpkg/status
     0.26.0+dfsg1-1+deb12u1 500
        500 https://deb.debian.org/debian bookworm/main amd64 Packages
        500 https://security.debian.org/debian-security bookworm-security/main amd64 Packages
        500 http://mirrors.xtom.nl/debian bookworm/main amd64 Packages
     0.25.0+dfsg1-2 -1000
       -1000 http://no.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
     0.23.0+dfsg1-1 500
        500 https://deb.debian.org/debian bullseye/main amd64 Packages
```