### PR TITLE
Update windows build instructions to include boost-beast dependency

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -119,7 +119,7 @@ Set up [vcpkg](https://github.com/Microsoft/vcpkg)
 Install dependencies
 
 ```sh
-vcpkg.exe install libflac libvorbis soxr opus boost-asio --triplet x64-windows
+vcpkg.exe install libflac libvorbis soxr opus boost-asio boost-beast --triplet x64-windows
 ```
 
 Build


### PR DESCRIPTION
Hi! tiny update to the Windows build instructions, as boost-beast is now a dependency which comes packaged separately on vcpkg