### PR TITLE
Add webOS support via SDL2 audio player

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Please follow this [guide](doc/build.md) to build Snapcast for
 - [OpenWrt](doc/build.md#openwrtlede-cross-compile)
 - [Buildroot](doc/build.md#buildroot-cross-compile)
 - [Raspberry Pi](doc/build.md#raspberry-pi-cross-compile)
+- [webOS](doc/build.md#webos-cross-compile)
 - [Windows](doc/build.md#windows-vcpkg)
+
 
 ## Configuration
 
@@ -121,6 +123,7 @@ Available audio backends are configured using the `--player` command line parame
 | opensl    | Android | OpenSL ES | |
 | coreaudio | macOS   | Core Audio | |
 | wasapi    | Windows | Windows Audio Session API | |
+| webos     | webOS   | SDL2 Audio for LG webOS TVs | |
 | file      | All     | Write audio to file | `filename=<filename>` (`<filename>` = `stdout`, `stderr`, `null` or a filename)<br>`mode=[w\|a]` (`w`: write (discarding the content), `a`: append (keeping the content) |
 
 Parameters are appended to the player name, e.g. `--player alsa:buffer_time=100`. Use `--player <name>:?` to get a list of available options.  

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -74,6 +74,20 @@ elseif(NOT ANDROID)
   endif(PIPEWIRE_FOUND)
 endif(MACOSX)
 
+# WebOS support
+if(TARGET_WEBOS)
+  add_compile_definitions(HAS_WEBOS)
+  list(APPEND CLIENT_SOURCES player/webos_player.cpp)
+  
+  # Find SDL2 for webOS audio
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SDL2 REQUIRED sdl2)
+  
+  list(APPEND CLIENT_LIBRARIES ${SDL2_LIBRARIES})
+  include_directories(${SDL2_INCLUDE_DIRS})
+  link_directories(${SDL2_LIBRARY_DIRS})
+endif()
+
 if(OPENSSL_FOUND)
   if(ANDROID)
     list(APPEND CLIENT_LIBRARIES openssl::crypto openssl::ssl)

--- a/client/controller.cpp
+++ b/client/controller.cpp
@@ -57,6 +57,10 @@
 #ifdef HAS_PIPEWIRE
 #include "player/pipewire_player.hpp"
 #endif
+#ifdef HAS_WEBOS
+#include "player/webos_player.hpp"
+#endif
+
 #include "player/file_player.hpp"
 
 #include "browseZeroConf/browse_zeroconf.hpp"
@@ -168,6 +172,10 @@ std::vector<std::string> Controller::getSupportedPlayerNames()
 #ifdef HAS_PIPEWIRE
     result.emplace_back(player::PIPEWIRE);
 #endif
+#ifdef HAS_WEBOS
+    result.emplace_back(player::WEBOS);
+#endif
+
     result.emplace_back(player::FILE);
     return result;
 }
@@ -278,6 +286,11 @@ void Controller::getNextMessage()
             if (!player_)
                 player_ = createPlayer<PipeWirePlayer>(settings_.player, player::PIPEWIRE);
 #endif
+#ifdef HAS_WEBOS
+            if (!player_)
+                player_ = createPlayer<WebOSPlayer>(settings_.player, player::WEBOS);
+#endif
+
             if (!player_ && (settings_.player.player_name == player::FILE))
                 player_ = createPlayer<FilePlayer>(settings_.player, player::FILE);
 

--- a/client/player/webos_player.cpp
+++ b/client/player/webos_player.cpp
@@ -1,0 +1,261 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+// prototype/interface header file
+#include "webos_player.hpp"
+
+// local headers
+#include "common/aixlog.hpp"
+#include "common/snap_exception.hpp"
+#include "common/utils/string_utils.hpp"
+
+// standard headers
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+using namespace std;
+
+namespace player
+{
+
+static constexpr auto LOG_TAG = "WebOSPlayer";
+
+WebOSPlayer::WebOSPlayer(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream)
+    : Player(io_context, settings, stream)
+    , audio_device_(0)
+    , initialized_(false)
+    , audio_active_(false)
+    , audio_buffer_(std::make_unique<char[]>(BUFFER_SIZE))
+    , buffer_fill_(0)
+{
+    LOG(INFO, LOG_TAG) << "WebOSPlayer created\n";
+}
+
+WebOSPlayer::~WebOSPlayer()
+{
+    stop();
+    cleanupAudio();
+    LOG(INFO, LOG_TAG) << "WebOSPlayer destroyed\n";
+}
+
+void WebOSPlayer::start()
+{
+    LOG(INFO, LOG_TAG) << "Starting WebOS player\n";
+    
+    if (!initializeAudio())
+    {
+        throw SnapException("Failed to initialize WebOS audio");
+    }
+    
+    Player::start();
+    audio_active_ = true;
+    
+    // Start SDL audio playback
+    SDL_PauseAudioDevice(audio_device_, 0);
+    
+    LOG(INFO, LOG_TAG) << "WebOS player started successfully\n";
+}
+
+void WebOSPlayer::stop()
+{
+    LOG(INFO, LOG_TAG) << "Stopping WebOS player\n";
+    
+    audio_active_ = false;
+    
+    if (audio_device_ != 0)
+    {
+        SDL_PauseAudioDevice(audio_device_, 1);
+    }
+    
+    Player::stop();
+    
+    LOG(INFO, LOG_TAG) << "WebOS player stopped\n";
+}
+
+bool WebOSPlayer::initializeAudio()
+{
+    LOG(INFO, LOG_TAG) << "Initializing SDL audio subsystem\n";
+    
+    if (SDL_Init(SDL_INIT_AUDIO) < 0)
+    {
+        LOG(ERROR, LOG_TAG) << "Failed to initialize SDL audio: " << SDL_GetError() << "\n";
+        return false;
+    }
+    
+    // Get the stream format
+    const auto& format = stream_->getFormat();
+    
+    // Configure SDL audio specification
+    SDL_zero(audio_spec_);
+    audio_spec_.freq = format.rate();
+    audio_spec_.format = AUDIO_S16LSB; // 16-bit signed little-endian
+    audio_spec_.channels = format.channels();
+    audio_spec_.samples = 1024; // Buffer size in samples
+    audio_spec_.callback = audioCallback;
+    audio_spec_.userdata = this;
+    
+    LOG(INFO, LOG_TAG) << "Audio format: " << format.rate() << "Hz, " 
+                       << format.channels() << " channels, " 
+                       << format.bits() << " bits\n";
+    
+    // Open audio device
+    SDL_AudioSpec obtained_spec;
+    audio_device_ = SDL_OpenAudioDevice(nullptr, 0, &audio_spec_, &obtained_spec, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+    
+    if (audio_device_ == 0)
+    {
+        LOG(ERROR, LOG_TAG) << "Failed to open audio device: " << SDL_GetError() << "\n";
+        SDL_Quit();
+        return false;
+    }
+    
+    LOG(INFO, LOG_TAG) << "Obtained audio format: " << obtained_spec.freq << "Hz, " 
+                       << (int)obtained_spec.channels << " channels\n";
+    
+    // Update our spec with what we actually got
+    audio_spec_ = obtained_spec;
+    initialized_ = true;
+    
+    return true;
+}
+
+void WebOSPlayer::cleanupAudio()
+{
+    if (audio_device_ != 0)
+    {
+        SDL_CloseAudioDevice(audio_device_);
+        audio_device_ = 0;
+    }
+    
+    if (initialized_)
+    {
+        SDL_Quit();
+        initialized_ = false;
+    }
+    
+    LOG(INFO, LOG_TAG) << "SDL audio cleaned up\n";
+}
+
+void WebOSPlayer::audioCallback(void* userdata, Uint8* stream, int len)
+{
+    WebOSPlayer* player = static_cast<WebOSPlayer*>(userdata);
+    
+    if (!player || !player->audio_active_)
+    {
+        // Fill with silence if not active
+        SDL_memset(stream, 0, len);
+        return;
+    }
+    
+    std::lock_guard<std::mutex> lock(player->buffer_mutex_);
+    
+    // Get audio data from snapcast stream
+    size_t available = player->buffer_fill_.load();
+    size_t bytes_to_copy = std::min(static_cast<size_t>(len), available);
+    
+    if (bytes_to_copy > 0)
+    {
+        std::memcpy(stream, player->audio_buffer_.get(), bytes_to_copy);
+        
+        // Move remaining data to front of buffer
+        if (bytes_to_copy < available)
+        {
+            std::memmove(player->audio_buffer_.get(),
+                        player->audio_buffer_.get() + bytes_to_copy,
+                        available - bytes_to_copy);
+            player->buffer_fill_.store(available - bytes_to_copy);
+        }
+        else
+        {
+            player->buffer_fill_.store(0);
+        }
+    }
+    
+    // Fill remaining with silence if needed
+    if (bytes_to_copy < static_cast<size_t>(len))
+    {
+        SDL_memset(stream + bytes_to_copy, 0, len - bytes_to_copy);
+    }
+}
+
+void WebOSPlayer::worker()
+{
+    LOG(INFO, LOG_TAG) << "WebOS player worker thread started\n";
+    
+    while (active_)
+    {
+        processAudio();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    
+    LOG(INFO, LOG_TAG) << "WebOS player worker thread stopped\n";
+}
+
+void WebOSPlayer::processAudio()
+{
+    if (!audio_active_ || !initialized_)
+        return;
+
+    std::lock_guard<std::mutex> lock(buffer_mutex_);
+
+    // Current fill in bytes
+    size_t fill = buffer_fill_.load();
+    if (fill >= BUFFER_SIZE)
+    {
+        LOG(DEBUG, LOG_TAG) << "Audio buffer full, skipping\n";
+        return;
+    }
+
+    // Determine how many frames we can ask for (frame = bytes per sample frame)
+    const auto& fmt = stream_->getFormat();
+    const size_t frame_size = fmt.frameSize();
+    if (frame_size == 0)
+        return;
+
+    size_t space = BUFFER_SIZE - fill;
+    uint32_t frames = static_cast<uint32_t>(space / frame_size);
+    if (frames == 0)
+        return;
+
+    // Fill buffer at current write position. getPlayerChunkOrSilence will write silence
+    // if no real data is available, so we always advance the fill by frames*frame_size.
+    stream_->getPlayerChunkOrSilence(audio_buffer_.get() + fill, chronos::usec{0}, frames);
+    buffer_fill_.fetch_add(static_cast<size_t>(frames) * frame_size);
+
+    // Apply the software mixer to the newly buffered PCM data.
+    // The server sends volume updates to the client; those updates end up in
+    // Player::volume_. We scale the samples here so the audio callback only
+    // needs to copy the already-adjusted data to SDL.
+    //
+    // A few notes for future readers:
+    // - adjustVolume expects a frame count (not bytes), so we pass `frames`.
+    // - adjustVolume takes the player mutex internally, so this call is
+    //   thread-safe with respect to setVolume() and other volume changes.
+    try
+    {
+        // frames = number of sample frames written into the buffer
+        adjustVolume(audio_buffer_.get() + fill, frames);
+    }
+    catch (const std::exception& e)
+    {
+        LOG(ERROR, LOG_TAG) << "adjustVolume failed: " << e.what() << "\n";
+    }
+}
+
+} // namespace player

--- a/client/player/webos_player.hpp
+++ b/client/player/webos_player.hpp
@@ -1,0 +1,86 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+// local headers
+#include "player.hpp"
+
+// 3rd party headers
+#include <SDL2/SDL.h>
+
+// standard headers
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace player
+{
+
+static constexpr auto WEBOS = "webos";
+
+/// WebOS Audio Player
+/**
+ * Audio player implementation for LG webOS using SDL2 audio subsystem
+ * Based on moonlight-tv's approach to webOS audio streaming
+ */
+class WebOSPlayer : public Player
+{
+public:
+    /// c'tor
+    WebOSPlayer(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream);
+    /// d'tor
+    virtual ~WebOSPlayer();
+
+    void start() override;
+    void stop() override;
+
+protected:
+    void worker() override;
+    bool needsThread() const override
+    {
+        return true;
+    }
+
+private:
+    /// SDL audio callback function
+    static void audioCallback(void* userdata, Uint8* stream, int len);
+    
+    /// Initialize SDL audio subsystem
+    bool initializeAudio();
+    
+    /// Cleanup SDL audio resources
+    void cleanupAudio();
+    
+    /// Process audio data from stream
+    void processAudio();
+
+    SDL_AudioDeviceID audio_device_;
+    SDL_AudioSpec audio_spec_;
+    std::atomic<bool> initialized_;
+    std::atomic<bool> audio_active_;
+    std::thread worker_thread_;
+    
+    // Audio buffer management
+    static constexpr size_t BUFFER_SIZE = 4096;
+    std::unique_ptr<char[]> audio_buffer_;
+    std::atomic<size_t> buffer_fill_;
+    mutable std::mutex buffer_mutex_;
+};
+
+} // namespace player

--- a/doc/build.md
+++ b/doc/build.md
@@ -223,3 +223,38 @@ To cross compile for OpenWrt, please follow the [OpenWrt flavored SnapOS guide](
 ### Buildroot (Cross compile)
 
 To integrate Snapcast into [Buildroot](https://buildroot.org/), please follow the [Buildroot flavored SnapOS guide](https://github.com/badaix/snapos/blob/master/buildroot-external/README.md)
+
+### webOS (Cross compile)
+
+To cross compile Snapcast client for LG webOS TVs, you need the webOS SDK and toolchain.
+
+#### Prerequisites
+
+1. Install the [openlgtv buildroot toolchain](https://github.com/openlgtv/buildroot-nc4)
+
+
+#### Build Steps
+
+1. Configure the build for webOS target:
+
+```sh
+mkdir build-webos
+cd build-webos
+
+# Configure with webOS toolchain
+cmake .. \
+    -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=/path/to/openlgtv/toolchain.cmake \
+    -DTARGET_WEBOS=ON \
+    -DBUILD_SERVER=OFF \
+    -DBUILD_CLIENT=ON \
+    -DBUILD_WITH_ALSA=OFF \
+    -DBUILD_WITH_PULSE=OFF \
+    -DBUILD_WITH_PIPEWIRE=OFF
+```
+
+2. Build the client:
+
+```sh
+cmake --build -j
+```


### PR DESCRIPTION
This PR adds support for building Snapclient to run on webOS TVs using SDL2 for audio output. The changes are minimal and focused on adding the necessary build system support and a new SDL2-based audio player implementation.

Changes
---------
- Add WebOSPlayer class implementing the player interface using SDL2 audio
- Add CMake configuration to detect and link SDL2 when building for webOS
- Wire up the new player in the client controller

Testing
--------
Tested manually on my LG webOS TV (webOS 24) with the following setup:
- Cross-compiled with openlgtv toolchain
- Configured with -DTARGET_WEBOS=ON -DCMAKE_TOOLCHAIN_FILE=/path/to/openlgtv/toolchain.cmake

Verified audio playback using:
- Tested volume control and buffer management
- No audio glitches or sync issues observed during >1h playback test

Implementation Notes
------------------------
- Uses SDL2's audio callback API for minimal latency
- Thread-safe buffer management between SDL callback and stream reader
- Proper cleanup/shutdown of SDL subsystem
- CMake detects SDL2 via pkg-config when TARGET_WEBOS is enabled

Packaging
-----------
I believe packaging of the client as a WebOS app is out of scope of this repo, and I intend to create a packaged version in a separate repository.

For testing purposes, the general gist of how I packaged and testing was:
- Create project structure, with required libs in `/usr/lib` (was just FLAC for me), and the built snapclient binary in in `/usr/bin`.
- Add basic appinfo.json, set `/usr/bin/launch.sh` as the entry point.
- Add a launch.sh which sets `LD_LIBRARY_PATH="$APPDIR/usr/lib:${LD_LIBRARY_PATH}"` tp load the required libraries, and starts the client `exec "$APPDIR/usr/bin/snapclient" --host 10.0.0.3 "$@" >>"$APPDIR/snapclient.log" 2>&1`.
- Create .ipk with `ares-package pkg` (from the [webos-tools/cli](https://github.com/webos-tools/cli) repo).

I personally then installed using webOS dev manager, as I don't have root, but you can also use `ares-install`.

The final structure:
```
pkg/
├── appinfo.json
├── usr/
│ ├── bin/
│ │ ├── snapclient # Built with TARGET_WEBOS=ON
│ │ └── launch.sh # Entry point script
│ └── lib/
│ └── libFLAC.so # Required shared libs
```