### PR TITLE
Use timing-safe string comparison for authn

### DIFF
--- a/client/player/pcm_device.hpp
+++ b/client/player/pcm_device.hpp
@@ -31,10 +31,10 @@ static constexpr char DEFAULT_DEVICE[] = "default";
 struct PcmDevice
 {
     /// c'tor
-    PcmDevice() : idx(-1), name(DEFAULT_DEVICE){};
+    PcmDevice() : idx(-1), name(DEFAULT_DEVICE) {};
 
     /// c'tor
-    PcmDevice(int idx, std::string name, std::string description = "") : idx(idx), name(std::move(name)), description(std::move(description)){};
+    PcmDevice(int idx, std::string name, std::string description = "") : idx(idx), name(std::move(name)), description(std::move(description)) {};
 
     /// index of the DAC (as in "aplay -L")
     int idx;

--- a/client/player/pipewire_player.cpp
+++ b/client/player/pipewire_player.cpp
@@ -292,7 +292,7 @@ void PipeWirePlayer::onProcess()
 #if PW_CHECK_VERSION(0, 3, 49)
     if (b->requested)
         n_frames = std::min<int>(static_cast<int>(b->requested), n_frames);
-        // LOG(TRACE, LOG_TAG) << "on_process - frames: " << n_frames << ", requested: " << b->requested << "\n";
+    // LOG(TRACE, LOG_TAG) << "on_process - frames: " << n_frames << ", requested: " << b->requested << "\n";
 #else
     // LOG(TRACE, LOG_TAG) << "on_process - frames: " << n_frames << "\n";
 #endif

--- a/common/message/message.hpp
+++ b/common/message/message.hpp
@@ -120,9 +120,9 @@ struct tv
     }
 
     /// C'tor, construct from timeval @p tv
-    explicit tv(timeval tv) : sec(tv.tv_sec), usec(tv.tv_usec){};
+    explicit tv(timeval tv) : sec(tv.tv_sec), usec(tv.tv_usec) {};
     /// C'tor, construct from @p _sec and @p _usec
-    tv(int32_t _sec, int32_t _usec) : sec(_sec), usec(_usec){};
+    tv(int32_t _sec, int32_t _usec) : sec(_sec), usec(_usec) {};
 
     /// seconds
     int32_t sec;

--- a/common/utils/string_utils.cpp
+++ b/common/utils/string_utils.cpp
@@ -272,4 +272,18 @@ std::string tolower_copy(const std::string& s)
     return tolower(str);
 }
 
+
+bool timing_safe_equals(const std::string a, const std::string b)
+{
+    volatile size_t i = 0;
+    volatile char result = (a.length() == b.length()) ? 0x00 : 0x01;
+    while (i < b.length())
+    {
+        result |= b[i] ^ (i < a.length() ? a[i] : 0x01);
+        ++i;
+    }
+    return (result == 0);
+}
+
+
 } // namespace utils::string

--- a/common/utils/string_utils.hpp
+++ b/common/utils/string_utils.hpp
@@ -127,4 +127,12 @@ std::string& tolower(std::string& s);
 std::string tolower_copy(const std::string& s);
 
 
+/// Compare @p a with @p b in time not dependent on the value of @p a
+/// or @p b. Intended for comparing credentials without introducing
+/// timing vulnerabilities. Timing depends on the length of @p b,
+/// which should be used for the user-provided input.
+/// @return true if strings are equal, otherwise false.
+bool timing_safe_equals(const std::string a, const std::string b);
+
+
 } // namespace utils::string

--- a/server/authinfo.cpp
+++ b/server/authinfo.cpp
@@ -112,7 +112,7 @@ ErrorCode AuthInfo::validateUser(const std::string& username, const std::optiona
                              [&](const ServerSettings::Authorization::User& user) { return user.name == username; });
     if (iter == auth_settings_.users.end())
         return ErrorCode{AuthErrc::unknown_user};
-    if (password.has_value() && (iter->password != password.value()))
+    if (password.has_value() && (!utils::string::timing_safe_equals(iter->password, password.value())))
         return ErrorCode{AuthErrc::wrong_password};
     return {};
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -107,6 +107,15 @@ TEST_CASE("String utils")
     std::string password = split_right(right, ':', role);
     REQUIRE(password == "password:with:colons");
     REQUIRE(role == "role");
+
+	REQUIRE(timing_safe_equals("", "") == true);
+	REQUIRE(timing_safe_equals("foo", "foo") == true);
+	REQUIRE(timing_safe_equals("foo", "") == false);
+	REQUIRE(timing_safe_equals("", "foo") == false);
+	REQUIRE(timing_safe_equals("foo", "bar") == false);
+	REQUIRE(timing_safe_equals("foo", "foobar") == false);
+	REQUIRE(timing_safe_equals("foobar", "foo") == false);
+	REQUIRE(timing_safe_equals("foobar", "foobaz") == false);
 }
 
 


### PR DESCRIPTION
Fixes #1469.