### PR TITLE
doc: update param name in librespot example

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -90,7 +90,7 @@ Parameters introduced by Snapclient:
 Add a stream source entry of type `process` which is briefly described further down, to `/etc/snapserver.conf` to launch [go-librespot](https://github.com/devgianlu/go-librespot) and read audio from stdout. Note that adding several more such stream sources with different profiles will require to have different configuration directories for `go-librespot`, each configured with different device name and server port accordingly:
 
 ```sh
-source = process:///<path/to/go-librespot>?name=<name>&sampleformat=44100:16:2&params=--config_dir%20/var/lib/snapserver/.config/go-librespot/<name>&dryout_ms=2000&wd_timeout=0&log_stderr=false&controlscript=meta_go-librespot.py&controlscriptparams=--stream=<name>%20--librespot-host=127.0.0.1%20--librespot-port=24879
+source = process:///<path/to/go-librespot>?name=<name>&sampleformat=44100:16:2&params=--config_dir%20/var/lib/snapserver/.config/go-librespot/<name>&idle_threshold=2000&wd_timeout=0&log_stderr=false&controlscript=meta_go-librespot.py&controlscriptparams=--stream=<name>%20--librespot-host=127.0.0.1%20--librespot-port=24879
 ```
 
 You need to have the `go-librespot` binary on your machine and a configuration file located in the path passed as `--config_dir` in the above source example, which of course need to be accessible to the snapserver user.


### PR DESCRIPTION
Replacing outdated `dryout_ms` example with `idle_threshold`.