### PR TITLE
Fix: Handle orphaned TCP stream connections (Last Connection Wins)

### DIFF
--- a/server/streamreader/asio_stream.hpp
+++ b/server/streamreader/asio_stream.hpp
@@ -30,6 +30,7 @@
 #include <boost/asio/steady_timer.hpp>
 
 // standard headers
+#include <chrono>
 
 
 namespace streamreader
@@ -195,6 +196,9 @@ void AsioStream<ReadStream>::do_read()
 
         if (ec)
         {
+            if (ec == boost::asio::error::operation_aborted)
+                return;
+
             if (lastException_ != ec.message())
             {
                 LOG(ERROR, "AsioStream") << "Error reading message: " << ec.message() << ", length: " << length << ", ec: " << ec << "\n";

--- a/server/streamreader/tcp_stream.cpp
+++ b/server/streamreader/tcp_stream.cpp
@@ -25,8 +25,10 @@
 #include "common/str_compat.hpp"
 
 // 3rd party headers
+#include <boost/asio/socket_base.hpp>
 
 // standard headers
+#include <chrono>
 #include <cstdint>
 #include <memory>
 
@@ -69,19 +71,8 @@ void TcpStream::connect()
 
     if (is_server_)
     {
-        acceptor_->async_accept([this, self = shared_from_this()](boost::system::error_code ec, tcp::socket socket)
-        {
-            if (!ec)
-            {
-                LOG(DEBUG, LOG_TAG) << "New client connection\n";
-                stream_ = make_unique<tcp::socket>(std::move(socket));
-                on_connect();
-            }
-            else
-            {
-                LOG(ERROR, LOG_TAG) << "Accept failed: " << ec.message() << "\n";
-            }
-        });
+        if (!accepting_)
+            start_accept();
     }
     else
     {
@@ -107,9 +98,39 @@ void TcpStream::connect()
 void TcpStream::disconnect()
 {
     reconnect_timer_.cancel();
-    if (acceptor_)
+    if (active_ == false && acceptor_)
         acceptor_->cancel();
     AsioStream<tcp::socket>::disconnect();
+}
+
+
+void TcpStream::start_accept()
+{
+    accepting_ = true;
+    acceptor_->async_accept([this, self = shared_from_this()](boost::system::error_code ec, tcp::socket socket)
+    {
+        accepting_ = false;
+        if (!ec)
+        {
+            boost::system::error_code ec;
+            socket.set_option(boost::asio::socket_base::keep_alive(true), ec);
+            socket.set_option(tcp::no_delay(true), ec);
+
+            LOG(NOTICE, LOG_TAG) << "New client connection: " << socket.remote_endpoint().address().to_string() << "\n";
+            stream_ = make_unique<tcp::socket>(std::move(socket));
+            on_connect();
+            start_accept();
+        }
+        else
+        {
+            if (ec != boost::asio::error::operation_aborted)
+            {
+                LOG(ERROR, LOG_TAG) << "Accept failed: " << ec.message() << "\n";
+                // Wait before retrying to avoid busy loop on persistent error
+                wait(reconnect_timer_, 1s, [this, self = shared_from_this()] { start_accept(); });
+            }
+        }
+    });
 }
 
 

--- a/server/streamreader/tcp_stream.hpp
+++ b/server/streamreader/tcp_stream.hpp
@@ -50,6 +50,8 @@ private:
     std::string host_;
     size_t port_;
     bool is_server_;
+    void start_accept();
+    bool accepting_ = false;
     boost::asio::steady_timer reconnect_timer_;
 };
 


### PR DESCRIPTION
## Description
This PR addresses the issue where TCP stream sources accumulate orphaned connections (zombies) that block new clients from connecting. This often happens when a source disconnects ungracefully (e.g., network failure) and the server keeps the socket in ESTABLISHED state, preventing subsequent connections to the same port.

## Changes
- **Implemented "Last Connection Wins" strategy**:
  - Modified [TcpStream](snapcast/server/streamreader/tcp_stream.hpp#42-45) to continuously accept new connections even if a stream is currently active.
  - When a new connection arrives, it automatically replaces the existing socket, effectively cleaning up the old/orphaned connection.
- **Enabled TCP KeepAlive**: Added `SO_KEEPALIVE` to generic TCP stream sockets to help the OS detect dead connections eventually.
- **Enabled TCP NoDelay**: Added `TCP_NODELAY` for lower latency.
- **Robust Error Handling**:
  - Updated `AsioStream::do_read` to ignore `boost::asio::error::operation_aborted` during the "replace" phase to prevent race conditions where the old stream's cancellation triggers an unwanted disconnect sequence.
  - Added a retry mechanism with a timer for [start_accept](snapcast/server/streamreader/tcp_stream.cpp#107-135) to prevent busy loops on accept errors.

## Verification
- Verified manually by running the server with `snapserver --stream.source="tcp://0.0.0.0:4953?name=test"`.
- Connected Client A (`nc localhost 4953`).
- Connected Client B (`nc localhost 4953`) while Client A was still active.
- Confirmed that Client B successfully took over the stream and the server logged the new connection.
- Confirmed that multiple sequential connections are handled correctly without restarting the server.

## Related Issues
Fixes issue with orphaned TCP connections blocking stream sources. #1480 
