### PR TITLE
PR: Zero copying in snapserver on TCP connections for audio data (updated)

### DIFF
--- a/.devcontainer/Dockerfile.fedora
+++ b/.devcontainer/Dockerfile.fedora
@@ -1,11 +1,13 @@
-ARG VARIANT="42"
+ARG VARIANT="43"
 FROM fedora:${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.
 RUN dnf -y update \
     && dnf -y install @development-tools gcc-c++ libstdc++-static libatomic cmake ccache ninja-build \
+    uv git nodejs pnpm \
     alsa-lib-devel avahi-devel boost-devel expat-devel flac-devel libvorbis-devel openssl-devel \
     opus-devel pipewire-jack-audio-connection-kit-devel pulseaudio-libs-devel soxr-devel \
+    pipewire-devel \
     && dnf clean all
 
 RUN useradd -rm -d /home/vscode -s /bin/bash -g root -u 1001 vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Snapcast-dev",
 	"build": {
-		"dockerfile": "Dockerfile.debian"
+		"dockerfile": "Dockerfile.fedora"
 		// "args": { "VARIANT": "alpine" }
 	},
 	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],

--- a/doc/zerocopy-server.md
+++ b/doc/zerocopy-server.md
@@ -1,0 +1,461 @@
+# Snapcast Server Zerocopy Implementation
+
+This document describes the MSG_ZEROCOPY implementation for Snapcast server networking, providing enhanced performance through kernel-level zero-copy transmission.
+
+## Overview
+
+The zerocopy implementation reduces CPU usage and memory bandwidth by allowing the kernel to send data directly from application buffers without additional copying. This is particularly beneficial for streaming large PCM audio chunks to multiple clients.
+
+## Configuration
+
+### Command Line Option
+
+Enable zerocopy networking with the `-z` flag:
+
+```bash
+./bin/snapserver -z -c snapserver.conf
+```
+
+The `-z` flag is a simple boolean switch that enables zerocopy for all client connections.
+
+### Configuration File
+
+Zerocopy can also be configured in the config file (e.g., `snapserver.conf`):
+
+```ini
+[stream]
+# Enable zerocopy networking for improved performance
+zerocopy = true
+```
+
+**Note**: The command line `-z` flag overrides the config file setting when present.
+
+### Usage Examples
+
+```bash
+# Enable via command line
+./bin/snapserver -z
+
+# Enable via config file
+echo "zerocopy = true" >> /etc/snapserver.conf
+./bin/snapserver
+
+# Command line overrides config file
+./bin/snapserver -z -c snapserver.conf  # zerocopy enabled
+```
+
+## Implementation Details
+
+### Critical Architecture Change: Buffer Lifetime Management
+
+A fundamental change was required for zerocopy: **changing the `sendAsync()` signature from**:
+
+```cpp
+// BEFORE: Reference to buffer (dangerous for zerocopy)
+virtual void sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler) = 0;
+
+// AFTER: Shared pointer to buffer (safe for zerocopy)  
+virtual void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) = 0;
+```
+
+#### Why This Change Was Essential
+
+**The Zerocopy Buffer Lifetime Problem**:
+1. **Zerocopy operations are asynchronous** - the kernel may send data long after `sendmsg()` returns
+2. **Kernel needs stable buffers** - the buffer must remain valid until the kernel completes transmission
+3. **Reference semantics are dangerous** - passing `const shared_const_buffer&` means the buffer could be destroyed while kernel is still using it
+4. **Stack unwinding risk** - if the calling function returns, stack-allocated buffers become invalid
+
+**The Solution - Shared Pointer Semantics**:
+1. **Guaranteed Lifetime** - `std::shared_ptr<shared_const_buffer>` ensures buffer lives until last reference is released
+2. **Reference Counting** - Buffer automatically freed only when both application and kernel are done with it
+3. **Zerocopy Safety** - Kernel completion notifications can safely decrement reference count
+4. **RAII Cleanup** - No manual memory management required
+
+#### Implementation in sendNext()
+
+The key change is in `StreamSession::sendNext()` at server/stream_session.cpp:55:
+
+```cpp
+void StreamSession::sendNext()
+{
+    auto& buffer = messages_.front();  // Reference to buffer in deque
+    buffer.on_air = true;
+    boost::asio::post(strand_, [this, self = shared_from_this(), buffer]()
+    {
+        // CRITICAL: Convert to shared_ptr for safe zerocopy buffer lifetime
+        auto buffer_ptr = std::make_shared<shared_const_buffer>(buffer);
+        
+        // Pass shared_ptr to sendAsync - buffer now guaranteed to live 
+        // until kernel completion notification
+        sendAsync(buffer_ptr, [this, buffer_ptr](boost::system::error_code ec, std::size_t length)
+        {
+            // buffer_ptr keeps buffer alive during this callback
+            auto write_handler = buffer_ptr->getWriteHandler();
+            if (write_handler)
+                write_handler(ec, length);
+            // buffer_ptr goes out of scope here - may trigger cleanup
+        });
+        // buffer_ptr may still be held by zerocopy system
+    });
+}
+```
+
+#### Multi-Client Buffer Sharing
+
+This change also enables **efficient buffer sharing across multiple clients**:
+
+1. **Same Audio Chunk, Multiple Clients** - When the same PCM chunk needs to go to multiple clients
+2. **Single Buffer Creation** - `shared_const_buffer` created once with pooled memory
+3. **Reference Counting** - Each client session gets its own `std::shared_ptr` to the same buffer
+4. **Automatic Cleanup** - Buffer freed only when all clients have completed transmission
+5. **Memory Efficiency** - One buffer copy instead of N copies for N clients
+
+#### Buffer Pool Integration
+
+The `shared_const_buffer` class has been enhanced with buffer pool integration:
+
+```cpp
+struct Message
+{
+    DynamicBufferPool::BufferGuard buffer_guard; ///< pooled buffer for data
+    size_t data_size;                             ///< actual size of data in buffer  
+    // ... other fields
+};
+```
+
+**Benefits**:
+- **Reduced Allocations** - Reuses pooled memory instead of malloc/free per message
+- **Size Bucketing** - Efficient memory management for different message sizes
+- **RAII Cleanup** - BufferGuard automatically returns buffer to pool
+- **Thread Safety** - Pool operations are thread-safe for multi-client scenarios
+
+### Architecture: Coordinated Approach
+
+Our implementation uses a **coordinated approach** that safely combines Boost.Asio async operations with direct MSG_ZEROCOPY syscalls. This design choice was made to:
+
+1. **Preserve Boost.Asio Benefits**: Keep all existing async patterns, error handling, and event loop integration
+2. **Avoid Complete Rewrite**: Minimize changes to existing codebase  
+3. **Ensure Safety**: Prevent race conditions between async and direct socket operations
+4. **Provide Graceful Fallback**: Automatic fallback when zerocopy is unavailable or inappropriate
+
+### Core Components
+
+**StreamSessionTcpCoordinated** (`server/stream_session_tcp_coordinated.hpp/cpp`)
+- Enhanced TCP session that coordinates zerocopy with Boost.Asio async operations
+- Uses direct `sendmsg()` with MSG_ZEROCOPY when socket is idle from async operations
+- Falls back to regular `boost::asio::async_write()` when async operations are pending
+- Provides comprehensive diagnostics and statistics
+
+**Stream Server Integration** (`server/stream_server.cpp`)
+- Creates coordinated sessions when zerocopy is enabled
+- Provides periodic diagnostics reporting every 30 seconds
+- Logs session creation: `"Creating zerocopy-enabled session"` vs `"Creating regular TCP session"`
+
+### Technical Implementation
+
+#### Coordination Mechanism
+- **Atomic Counter**: `pending_async_operations_` tracks active Boost.Asio operations
+- **Safe Zerocopy**: Only uses MSG_ZEROCOPY when counter is 0 (socket idle)  
+- **Mutual Exclusion**: Regular async operations increment counter, blocking zerocopy
+- **Race Prevention**: Atomic compare-and-swap prevents race conditions
+
+#### Operation Flow
+1. **Large Messages (≥1024 bytes)**: Try zerocopy first, fallback to async if socket busy
+2. **Small Messages (<1024 bytes)**: Use regular async operations (more efficient)
+3. **Busy Socket**: Queue operations and process when socket becomes idle
+4. **Error Handling**: Monitor kernel error queue for zerocopy completion notifications
+
+## Race Condition Avoidance
+
+### The Challenge
+Mixing Boost.Asio async operations with direct syscalls creates potential race conditions:
+```cpp
+// DANGEROUS: Check-then-act race condition
+if (no_async_operations_pending) {  // ✓ Check passes
+    // Another thread could start async_write here!
+    sendmsg(socket, MSG_ZEROCOPY);  // ✗ Now mixing operations!
+}
+```
+
+### Our Solution: Atomic Reservation
+
+**1. Atomic Compare-and-Swap Pattern**
+```cpp
+bool StreamSessionTcpCoordinated::tryReserveZeroCopy()
+{
+    uint32_t expected = 0;
+    while (!pending_async_operations_.compare_exchange_weak(expected, 1))
+    {
+        if (expected != 0)
+            return false; // Another operation is in progress
+        // Retry on spurious failures (expected reloaded with current value)
+    }
+    return true; // Successfully reserved zerocopy
+}
+```
+
+**2. Coordination Points**
+- **Regular Async Operations**: 
+  - Increment counter before starting: `pending_async_operations_++`
+  - Decrement in completion handler: `pending_async_operations_--`
+- **Zerocopy Operations**:
+  - Reserve atomically: `tryReserveZeroCopy()` (sets to 1)  
+  - Release when done: `releaseZeroCopy()` (sets to 0)
+
+**3. Race Prevention Guarantees**
+- **Atomic Operations**: All counter access uses atomic operations
+- **No Check-Then-Act**: The compare-and-swap is atomic, no gap for races
+- **Spurious Failure Handling**: Retry loop handles `compare_exchange_weak` spurious failures
+- **Mutual Exclusion**: Both systems use same counter, ensuring exclusive access
+
+### Why Compare-and-Swap Works
+
+The atomic `compare_exchange_weak()` operation:
+1. **Atomically** checks if `pending_async_operations_ == 0` (idle)
+2. **Atomically** sets it to `1` (reserved) if idle
+3. **Returns false** if another operation started between check and set
+4. **Handles spurious failures** by retrying in a loop
+
+This eliminates the race window completely - there's no gap between checking and acting.
+
+## Alternative Approaches Considered
+
+### 1. Pure Boost.Asio Zerocopy
+- **Pros**: Clean integration, no race conditions
+- **Cons**: Boost.Asio doesn't natively support MSG_ZEROCOPY, would require extensive framework modifications
+
+### 2. Separate Zerocopy Socket Class  
+- **Pros**: Complete control over zerocopy operations
+- **Cons**: Duplicate async infrastructure, more complex error handling, larger codebase changes
+
+### 3. Strand-Based Serialization
+- **Pros**: Boost.Asio strand ensures serialized access
+- **Cons**: All operations must go through strand, potential performance impact
+
+### 4. Mutex-Based Locking
+- **Pros**: Simple exclusive access
+- **Cons**: Blocking operations, potential latency impact, doesn't align with async patterns
+
+**Our Choice**: The coordinated approach provides the best balance of safety, performance, and integration simplicity.
+
+## Comprehensive Diagnostics System
+
+### Real-time Statistics Tracking
+
+The implementation includes comprehensive statistics with atomic counters for thread safety:
+
+- **Zerocopy Operations**: Count and bytes sent via MSG_ZEROCOPY
+- **Regular Operations**: Count and bytes sent via standard async_write  
+- **Coordination Fallbacks**: When zerocopy is skipped due to pending async operations
+- **Outstanding Operations**: Number of zerocopy operations pending kernel completion
+- **Success Rate**: Percentage of operations using zerocopy vs regular sends
+
+### ZeroCopyStats Structure
+
+Each coordinated session tracks detailed statistics with automatic reset after each report:
+
+```cpp
+struct ZeroCopyStats {
+    uint64_t zerocopy_attempts{0};      // Total zerocopy send attempts
+    uint64_t zerocopy_successful{0};    // Successful zerocopy sends  
+    uint64_t zerocopy_bytes{0};         // Total bytes sent via zerocopy
+    uint64_t regular_sends{0};          // Messages sent via async_write
+    uint64_t regular_bytes{0};          // Total bytes sent via async_write
+    uint64_t coordination_fallbacks{0}; // Fallbacks due to pending async ops
+    uint64_t outstanding_operations{0}; // Currently outstanding zerocopy operations in kernel
+    double zerocopy_percentage() const; // Success rate calculation
+};
+```
+
+### Statistics Management
+
+**Automatic Reset**: Statistics are reset after each periodic report to show current performance trends rather than lifetime accumulated values. This provides:
+- **Current Performance**: Each 30-second report shows recent activity, not lifetime totals
+- **Trend Analysis**: Easier to identify performance changes over time  
+- **Memory Management Tracking**: Outstanding operations counter shows kernel buffer usage
+- **Fresh Diagnostics**: Each report period starts with clean counters
+
+**Buffer Lifecycle Tracking**: The `outstanding_operations` counter tracks zerocopy buffers:
+- **Incremented**: When `sendmsg()` succeeds with MSG_ZEROCOPY
+- **Decremented**: When kernel completion notifications are received via error queue
+- **Purpose**: Monitor memory pressure and kernel buffer usage
+
+### Periodic Reporting
+
+Every 30 seconds, when clients are connected, the server logs zerocopy diagnostics then resets all counters:
+
+```
+=== Periodic ZeroCopy Status (every 30s) ===
+Zerocopy Stats for session 192.168.1.100
+	ZC Attempts: 1250, 
+	ZC Successful: 1200, 
+	ZC Bytes: 15728640, 
+	Regular Sends: 45, 
+	Regular Bytes: 2048, 
+	Coordination Fallbacks: 5, 
+	Outstanding Operations: 12,
+	ZC Success Rate: 96.00%
+```
+
+**Note**: After this report, all counters except `outstanding_operations` are reset to zero. The next 30-second report will show fresh statistics from that point forward.
+
+## Testing and Verification
+
+### How to Test Zerocopy
+
+1. **Start the server with zerocopy enabled**: 
+   ```bash
+   ./bin/snapserver -z -c snapserver.conf
+   ```
+
+2. **Connect clients**:
+   ```bash
+   scripts/run-snapclient.sh
+   ```
+
+3. **Monitor logs** for zerocopy diagnostics messages
+
+### What the Logs Tell You
+
+#### Connection Messages
+- `"Creating zerocopy-enabled session for 192.168.1.100"` - Zerocopy is working
+- `"Creating regular TCP session for 192.168.1.100"` - Zerocopy disabled or not working
+- `"ZeroCopy setting: enabled"` - Shows zerocopy configuration status at startup
+
+#### Performance Indicators
+
+**High Performance (Working Well)**:
+- High zerocopy success rate (>90%)
+- Low coordination fallbacks
+- Large byte ratios for zerocopy vs regular
+
+**Potential Issues**:
+- High coordination fallbacks - Socket frequently busy with async operations  
+- Low success rate - MSG_ZEROCOPY not available or network issues
+- Zero successful attempts - Kernel doesn't support zerocopy
+
+#### Example Good Performance
+```
+ZC Success Rate: 98.20%
+ZC Successful: 1200
+Coordination Fallbacks: 5
+```
+
+#### Example Coordination Issues  
+```
+ZC Success Rate: 45.00%  
+ZC Successful: 450
+Coordination Fallbacks: 550  # High fallback rate
+```
+
+## Troubleshooting
+
+### Zerocopy Not Available
+If zerocopy is not working:
+
+1. **Check kernel version**: MSG_ZEROCOPY requires Linux kernel 4.14+
+2. **Check socket buffer limits**: May need to increase `net.core.optmem_max`
+3. **Check permissions**: Some containers may restrict socket options
+4. **Review startup logs**: Look for `"ZeroCopy setting: disabled"` messages
+
+### Performance Issues
+
+1. **High coordination fallbacks**: 
+   - High async operation frequency (normal for small messages)
+   - Very active client connections
+   - Consider this normal behavior - the system is working as designed
+
+2. **Low success rate with low fallbacks**:
+   - Kernel zerocopy issues (EAGAIN, insufficient buffers)
+   - Network congestion  
+   - Check system limits and kernel messages
+
+### Configuration Verification
+
+To verify your configuration:
+
+```bash
+# Check command line help
+./bin/snapserver -h
+
+# Check config file options  
+./bin/snapserver -hh | grep -i zerocopy
+```
+
+## Performance Benefits
+
+When working correctly, the coordinated zerocopy approach provides:
+
+- **Reduced CPU usage**: Eliminates memory copying in kernel for large messages
+- **Lower memory bandwidth**: Direct buffer transmission
+- **Better scalability**: More efficient with multiple clients  
+- **Maintained Async Benefits**: Keeps all Boost.Asio advantages
+- **Safe Operation**: No race conditions or undefined behavior
+
+The diagnostics system allows real-time monitoring of these benefits and helps identify any coordination or performance issues.
+
+## Additional Optimizations
+
+### Buffer Pool Memory Management
+
+The implementation includes a `DynamicBufferPool` (`common/buffer_pool.hpp/cpp`) that significantly reduces memory allocation overhead:
+
+**Features**:
+- **Size Buckets**: Powers of 2 sizing (1024, 2048, 4096, etc.) for efficient reuse
+- **RAII Management**: `BufferGuard` automatically returns buffers to pool
+- **Thread Safety**: Atomic statistics and mutex protection for multi-client scenarios
+- **Automatic Cleanup**: Idle buffers cleaned up after 5 minutes
+- **Statistics Tracking**: Pool efficiency metrics logged every 30 seconds
+
+**Integration**: 
+- `shared_const_buffer` uses pooled memory via `DynamicBufferPool::BufferGuard`
+- Audio message serialization reuses buffers instead of individual malloc/free
+- Significant allocation reduction in multi-client streaming scenarios
+
+**Statistics Logged**:
+```
+=== Buffer Pool Stats ===
+	Total Buffers: 16
+	Available Buffers: 16  
+	Bytes Allocated: 65536
+	Buffers Created: 0
+	Buffers Reused: 6088
+	Cleanup Operations: 0
+```
+
+### Optimized Logging System
+
+The logging system (`common/aixlog.hpp/cpp`) has been enhanced with caching for better performance:
+
+**Optimization**: 
+- `should_log()` results cached with hash map: `(severity, tag) -> bool`
+- `LOG()` macro uses `should_log_cached()` to avoid repeated filter evaluations
+- Cache automatically invalidated when sink configuration changes
+- LRU-style eviction prevents memory growth
+
+**Performance Impact**:
+- Eliminates repeated filter matching for frequent log calls
+- Reduces string construction overhead for filtered-out messages
+- Particularly beneficial for TRACE/DEBUG logging in production
+
+**Cache Statistics** (accessible via `getShouldLogCacheStats()`):
+- Cache hits/misses for performance monitoring
+- Cache size for memory usage tracking
+- Automatic cache clearing on configuration changes
+
+## Integration Notes
+
+- **Backward Compatible**: Automatically falls back to regular async operations when zerocopy unavailable
+- **Thread Safe**: All statistics and coordination use atomic operations
+- **Boost.Asio Compatible**: Full integration with existing async patterns
+- **Configurable**: Enable via command line (`-z`) or config file (`zerocopy = true`)
+- **Memory Optimized**: Buffer pool and log caching reduce allocation overhead
+- **Comprehensive Diagnostics**: Real-time monitoring of zerocopy, buffer pool, and cache performance
+- **Zero Code Changes**: Existing client code unchanged, transparent enhancement
+
+## Acknowledgements
+
+Research for this implementation was done with perplexity AI. Most of the inital code was written by Claude Code AI, including this documentation.
+
+However, all tests, prompt directions, and the initial PR were done by [aanno](https://github.com/aanno).

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SERVER_SOURCES
     stream_server.cpp
     stream_session.cpp
     stream_session_tcp.cpp
+    stream_session_tcp_coordinated.cpp
     stream_session_ws.cpp
     encoder/encoder_factory.cpp
     encoder/pcm_encoder.cpp

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -12,7 +12,6 @@ set(SERVER_SOURCES
     stream_server.cpp
     stream_session.cpp
     stream_session_tcp.cpp
-    stream_session_tcp_coordinated.cpp
     stream_session_ws.cpp
     encoder/encoder_factory.cpp
     encoder/pcm_encoder.cpp
@@ -128,6 +127,11 @@ else()
     include_directories(${SOXR_INCLUDE_DIRS})
     link_directories(${SOXR_LIBRARY_DIRS})
   endif(SOXR_FOUND)
+
+  # Zero-copy TCP stream session (Linux only - uses MSG_ZEROCOPY and linux/errqueue.h)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND SERVER_SOURCES stream_session_tcp_coordinated.cpp)
+  endif()
 endif()
 
 if(OPENSSL_FOUND)

--- a/server/server_settings.hpp
+++ b/server/server_settings.hpp
@@ -228,6 +228,8 @@ struct ServerSettings
         size_t streamChunkMs{20};
         /// Send audio to muted clients?
         bool sendAudioToMutedClients{false};
+        /// Enable zerocopy networking for improved performance
+        bool zerocopy{false};
     };
 
     /// Client settings

--- a/server/snapserver.cpp
+++ b/server/snapserver.cpp
@@ -74,6 +74,7 @@ int main(int argc, char* argv[])
         auto daemonOption = op.add<Implicit<int>>("d", "daemon", "Daemonize\noptional process priority [-20..19]", 0, &processPriority);
 #endif
         auto config_file_option = op.add<Value<string>>("c", "config", "Path to the configuration file", config_file, &config_file);
+        auto zerocopy_switch = op.add<Switch>("z", "zerocopy", "Enable zerocopy networking for improved performance");
 
         OptionParser conf("Overridable config file options");
 
@@ -166,6 +167,7 @@ int main(int argc, char* argv[])
         conf.add<Value<int>>("", "stream.buffer", "Buffer [ms]", settings.stream.bufferMs, &settings.stream.bufferMs);
         conf.add<Value<bool>>("", "stream.send_to_muted", "Send audio to muted clients", settings.stream.sendAudioToMutedClients,
                               &settings.stream.sendAudioToMutedClients);
+        conf.add<Value<bool>>("", "stream.zerocopy", "Enable zerocopy networking for improved performance", settings.stream.zerocopy, &settings.stream.zerocopy);
 
         // streaming_client options
         conf.add<Value<uint16_t>>("", "streaming_client.initial_volume", "Volume [percent] assigned to new streaming clients",
@@ -232,6 +234,12 @@ int main(int argc, char* argv[])
             }
             else
                 cerr << "Warning - Failed to load config file '" << config_file << "': " << e.what() << "\n";
+        }
+
+        // Override zerocopy setting if -z flag is provided
+        if (zerocopy_switch->is_set())
+        {
+            settings.stream.zerocopy = true;
         }
 
         if (settings.stream.codec.find(":?") != string::npos)
@@ -373,6 +381,8 @@ int main(int argc, char* argv[])
         }
 
         LOG(INFO, LOG_TAG) << "Version " << version::code << (!version::rev().empty() ? (", revision " + version::rev(8)) : ("")) << "\n";
+
+        LOG(INFO, LOG_TAG) << "ZeroCopy setting: " << (settings.stream.zerocopy ? "enabled" : "disabled") << "\n";
 
         if (settings.ssl.enabled())
             LOG(INFO, LOG_TAG) << "SSL enabled - certificate file: '" << settings.ssl.certificate.native() << "', certificate key file: '"

--- a/server/snapserver.cpp
+++ b/server/snapserver.cpp
@@ -167,7 +167,8 @@ int main(int argc, char* argv[])
         conf.add<Value<int>>("", "stream.buffer", "Buffer [ms]", settings.stream.bufferMs, &settings.stream.bufferMs);
         conf.add<Value<bool>>("", "stream.send_to_muted", "Send audio to muted clients", settings.stream.sendAudioToMutedClients,
                               &settings.stream.sendAudioToMutedClients);
-        conf.add<Value<bool>>("", "stream.zerocopy", "Enable zerocopy networking for improved performance", settings.stream.zerocopy, &settings.stream.zerocopy);
+        conf.add<Value<bool>>("", "stream.zerocopy", "Enable zerocopy networking for improved performance", settings.stream.zerocopy,
+                              &settings.stream.zerocopy);
 
         // streaming_client options
         conf.add<Value<uint16_t>>("", "streaming_client.initial_volume", "Volume [percent] assigned to new streaming clients",

--- a/server/stream_server.cpp
+++ b/server/stream_server.cpp
@@ -42,7 +42,9 @@ using namespace streamreader;
 using json = nlohmann::json;
 
 static constexpr auto LOG_TAG = "StreamServer";
+#ifdef __linux__
 static constexpr auto LOG_STATS_TAG = "StreamServerStats";
+#endif
 
 StreamServer::StreamServer(boost::asio::io_context& io_context, ServerSettings serverSettings, StreamMessageReceiver* messageReceiver)
     : io_context_(io_context), config_timer_(io_context), diagnostics_timer_(io_context), settings_(std::move(serverSettings)), messageReceiver_(messageReceiver)

--- a/server/stream_server.cpp
+++ b/server/stream_server.cpp
@@ -23,7 +23,9 @@
 #include "common/aixlog.hpp"
 #include "config.hpp"
 #include "stream_session_tcp.hpp"
+#ifdef __linux__
 #include "stream_session_tcp_coordinated.hpp"
+#endif
 
 // standard headers
 #include <iomanip>
@@ -217,12 +219,14 @@ void StreamServer::handleAccept(tcp::socket socket)
         LOG(NOTICE, LOG_TAG) << "StreamServer::NewConnection: " << socket.remote_endpoint().address().to_string() << "\n";
         
         shared_ptr<StreamSession> session;
+#ifdef __linux__
         if (settings_.stream.zerocopy)
         {
             LOG(INFO, LOG_TAG) << "Creating zerocopy-enabled session for " << socket.remote_endpoint().address().to_string() << "\n";
             session = make_shared<StreamSessionTcpCoordinated>(this, settings_, std::move(socket));
         }
         else
+#endif
         {
             LOG(DEBUG, LOG_TAG) << "Creating regular TCP session for " << socket.remote_endpoint().address().to_string() << "\n";
             session = make_shared<StreamSessionTcp>(this, settings_, std::move(socket));
@@ -277,6 +281,7 @@ void StreamServer::stop()
     }
 }
 
+#ifdef __linux__
 void StreamServer::printZeroCopyDiagnostics(StreamSessionTcpCoordinated* /* coordinated_session */) const
 {
     // Aggregate stats from all zerocopy sessions
@@ -340,6 +345,7 @@ void StreamServer::printZeroCopyDiagnostics(StreamSessionTcpCoordinated* /* coor
         }).detach();
     }
 }
+#endif // __linux__
 
 void StreamServer::startDiagnosticsTimer()
 {
@@ -358,12 +364,14 @@ void StreamServer::startDiagnosticsTimer()
                 {
                     if (auto session = s.lock())
                     {
+#ifdef __linux__
                         // Handle zerocopy diagnostics
                         if (auto coordinated_session = std::dynamic_pointer_cast<StreamSessionTcpCoordinated>(session))
                         {
                             LOG(INFO, LOG_TAG) << "=== Periodic ZeroCopy Status (every 30s) ===\n";
                             printZeroCopyDiagnostics(coordinated_session.get());
                         }
+#endif
                     }
                 }
             }

--- a/server/stream_server.cpp
+++ b/server/stream_server.cpp
@@ -47,7 +47,8 @@ static constexpr auto LOG_STATS_TAG = "StreamServerStats";
 #endif
 
 StreamServer::StreamServer(boost::asio::io_context& io_context, ServerSettings serverSettings, StreamMessageReceiver* messageReceiver)
-    : io_context_(io_context), config_timer_(io_context), diagnostics_timer_(io_context), settings_(std::move(serverSettings)), messageReceiver_(messageReceiver)
+    : io_context_(io_context), config_timer_(io_context), diagnostics_timer_(io_context), settings_(std::move(serverSettings)),
+      messageReceiver_(messageReceiver)
 {
 }
 
@@ -219,7 +220,7 @@ void StreamServer::handleAccept(tcp::socket socket)
         socket.set_option(tcp::no_delay(true));
 
         LOG(NOTICE, LOG_TAG) << "StreamServer::NewConnection: " << socket.remote_endpoint().address().to_string() << "\n";
-        
+
         shared_ptr<StreamSession> session;
 #ifdef __linux__
         if (settings_.stream.zerocopy)
@@ -233,7 +234,7 @@ void StreamServer::handleAccept(tcp::socket socket)
             LOG(DEBUG, LOG_TAG) << "Creating regular TCP session for " << socket.remote_endpoint().address().to_string() << "\n";
             session = make_shared<StreamSessionTcp>(this, settings_, std::move(socket));
         }
-        
+
         addSession(session);
     }
     catch (const std::exception& e)
@@ -289,11 +290,14 @@ void StreamServer::printZeroCopyDiagnostics(StreamSessionTcpCoordinated* /* coor
     // Aggregate stats from all zerocopy sessions
     StreamSessionTcpCoordinated::ZeroCopyStats aggregated_stats = {};
     int zerocopy_session_count = 0;
-    
+
     std::lock_guard<std::recursive_mutex> mlock(sessionsMutex_);
-    for (const auto& s : sessions_) {
-        if (auto session = s.lock()) {
-            if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get())) {
+    for (const auto& s : sessions_)
+    {
+        if (auto session = s.lock())
+        {
+            if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get()))
+            {
                 auto stats = zc_session->getZeroCopyStats();
                 aggregated_stats.zerocopy_attempts += stats.zerocopy_attempts;
                 aggregated_stats.zerocopy_successful += stats.zerocopy_successful;
@@ -310,38 +314,42 @@ void StreamServer::printZeroCopyDiagnostics(StreamSessionTcpCoordinated* /* coor
             }
         }
     }
-    
+
     // Only print once for all sessions
     static bool already_printed = false;
-    if (!already_printed && zerocopy_session_count > 0) {
+    if (!already_printed && zerocopy_session_count > 0)
+    {
         already_printed = true;
-        
+
         LOG(INFO, LOG_STATS_TAG) << "=== Aggregated ZeroCopy Stats (All " << zerocopy_session_count << " Sessions) ==="
-                           << "\n\tZC Attempts: " << aggregated_stats.zerocopy_attempts << ", "
-                           << "\n\tZC Successful: " << aggregated_stats.zerocopy_successful << ", "
-                           << "\n\tZC Bytes: " << aggregated_stats.zerocopy_bytes << ", "
-                           << "\n\tRegular Sends: " << aggregated_stats.regular_sends << ", "
-                           << "\n\tRegular Bytes: " << aggregated_stats.regular_bytes << ", "
-                           << "\n\tCoordination Fallbacks: " << aggregated_stats.coordination_fallbacks << ", "
-                           << "\n\tPending Async Operations: " << aggregated_stats.pending_async_operations << ", "
-                           << "\n\tOutstanding ZC Buffers: " << aggregated_stats.outstanding_zerocopy_buffers << ", "
-                           << "\n\tCompletion Notifications: " << aggregated_stats.completion_notifications_received << ", "
-                           << "\n\tMissing Notifications: " << aggregated_stats.completion_notifications_missing << ", "
-                           << std::fixed << std::setprecision(2)
-                           << "\n\tZC Success Rate: " << aggregated_stats.zerocopy_percentage() << "%"
-                           << "\n\tCompletion Reliability: " << aggregated_stats.completion_reliability() << "%\n";
-        
+                                 << "\n\tZC Attempts: " << aggregated_stats.zerocopy_attempts << ", "
+                                 << "\n\tZC Successful: " << aggregated_stats.zerocopy_successful << ", "
+                                 << "\n\tZC Bytes: " << aggregated_stats.zerocopy_bytes << ", "
+                                 << "\n\tRegular Sends: " << aggregated_stats.regular_sends << ", "
+                                 << "\n\tRegular Bytes: " << aggregated_stats.regular_bytes << ", "
+                                 << "\n\tCoordination Fallbacks: " << aggregated_stats.coordination_fallbacks << ", "
+                                 << "\n\tPending Async Operations: " << aggregated_stats.pending_async_operations << ", "
+                                 << "\n\tOutstanding ZC Buffers: " << aggregated_stats.outstanding_zerocopy_buffers << ", "
+                                 << "\n\tCompletion Notifications: " << aggregated_stats.completion_notifications_received << ", "
+                                 << "\n\tMissing Notifications: " << aggregated_stats.completion_notifications_missing << ", " << std::fixed
+                                 << std::setprecision(2) << "\n\tZC Success Rate: " << aggregated_stats.zerocopy_percentage() << "%"
+                                 << "\n\tCompletion Reliability: " << aggregated_stats.completion_reliability() << "%\n";
+
         // Reset stats after reporting for all sessions
-        for (const auto& s : sessions_) {
-            if (auto session = s.lock()) {
-                if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get())) {
+        for (const auto& s : sessions_)
+        {
+            if (auto session = s.lock())
+            {
+                if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get()))
+                {
                     zc_session->resetZeroCopyStats();
                 }
             }
         }
-        
+
         // Reset the flag for next reporting cycle
-        std::thread([]{
+        std::thread([]
+        {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             already_printed = false;
         }).detach();
@@ -356,7 +364,7 @@ void StreamServer::startDiagnosticsTimer()
     {
         if (ec)
             return;
-        
+
         // Only print diagnostics if there are active sessions
         {
             std::lock_guard<std::recursive_mutex> mlock(sessionsMutex_);
@@ -378,7 +386,7 @@ void StreamServer::startDiagnosticsTimer()
                 }
             }
         }
-        
+
         // Schedule next diagnostics check
         startDiagnosticsTimer();
     });

--- a/server/stream_server.cpp
+++ b/server/stream_server.cpp
@@ -23,6 +23,11 @@
 #include "common/aixlog.hpp"
 #include "config.hpp"
 #include "stream_session_tcp.hpp"
+#include "stream_session_tcp_coordinated.hpp"
+
+// standard headers
+#include <iomanip>
+#include <thread>
 
 // 3rd party headers
 
@@ -35,9 +40,10 @@ using namespace streamreader;
 using json = nlohmann::json;
 
 static constexpr auto LOG_TAG = "StreamServer";
+static constexpr auto LOG_STATS_TAG = "StreamServerStats";
 
 StreamServer::StreamServer(boost::asio::io_context& io_context, ServerSettings serverSettings, StreamMessageReceiver* messageReceiver)
-    : io_context_(io_context), config_timer_(io_context), settings_(std::move(serverSettings)), messageReceiver_(messageReceiver)
+    : io_context_(io_context), config_timer_(io_context), diagnostics_timer_(io_context), settings_(std::move(serverSettings)), messageReceiver_(messageReceiver)
 {
 }
 
@@ -209,7 +215,19 @@ void StreamServer::handleAccept(tcp::socket socket)
         socket.set_option(tcp::no_delay(true));
 
         LOG(NOTICE, LOG_TAG) << "StreamServer::NewConnection: " << socket.remote_endpoint().address().to_string() << "\n";
-        shared_ptr<StreamSession> session = make_shared<StreamSessionTcp>(this, settings_, std::move(socket));
+        
+        shared_ptr<StreamSession> session;
+        if (settings_.stream.zerocopy)
+        {
+            LOG(INFO, LOG_TAG) << "Creating zerocopy-enabled session for " << socket.remote_endpoint().address().to_string() << "\n";
+            session = make_shared<StreamSessionTcpCoordinated>(this, settings_, std::move(socket));
+        }
+        else
+        {
+            LOG(DEBUG, LOG_TAG) << "Creating regular TCP session for " << socket.remote_endpoint().address().to_string() << "\n";
+            session = make_shared<StreamSessionTcp>(this, settings_, std::move(socket));
+        }
+        
         addSession(session);
     }
     catch (const std::exception& e)
@@ -240,6 +258,7 @@ void StreamServer::start()
     }
 
     startAccept();
+    startDiagnosticsTimer();
 }
 
 
@@ -256,4 +275,101 @@ void StreamServer::stop()
         if (auto session = s.lock())
             session->stop();
     }
+}
+
+void StreamServer::printZeroCopyDiagnostics(StreamSessionTcpCoordinated* /* coordinated_session */) const
+{
+    // Aggregate stats from all zerocopy sessions
+    StreamSessionTcpCoordinated::ZeroCopyStats aggregated_stats = {};
+    int zerocopy_session_count = 0;
+    
+    std::lock_guard<std::recursive_mutex> mlock(sessionsMutex_);
+    for (const auto& s : sessions_) {
+        if (auto session = s.lock()) {
+            if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get())) {
+                auto stats = zc_session->getZeroCopyStats();
+                aggregated_stats.zerocopy_attempts += stats.zerocopy_attempts;
+                aggregated_stats.zerocopy_successful += stats.zerocopy_successful;
+                aggregated_stats.zerocopy_bytes += stats.zerocopy_bytes;
+                aggregated_stats.regular_sends += stats.regular_sends;
+                aggregated_stats.regular_bytes += stats.regular_bytes;
+                aggregated_stats.coordination_fallbacks += stats.coordination_fallbacks;
+                aggregated_stats.pending_async_operations += stats.pending_async_operations;
+                aggregated_stats.outstanding_zerocopy_buffers += stats.outstanding_zerocopy_buffers;
+                aggregated_stats.completion_notifications_received += stats.completion_notifications_received;
+                aggregated_stats.completion_notifications_missing += stats.completion_notifications_missing;
+                aggregated_stats.buffers_completed_via_notifications += stats.buffers_completed_via_notifications;
+                zerocopy_session_count++;
+            }
+        }
+    }
+    
+    // Only print once for all sessions
+    static bool already_printed = false;
+    if (!already_printed && zerocopy_session_count > 0) {
+        already_printed = true;
+        
+        LOG(INFO, LOG_STATS_TAG) << "=== Aggregated ZeroCopy Stats (All " << zerocopy_session_count << " Sessions) ==="
+                           << "\n\tZC Attempts: " << aggregated_stats.zerocopy_attempts << ", "
+                           << "\n\tZC Successful: " << aggregated_stats.zerocopy_successful << ", "
+                           << "\n\tZC Bytes: " << aggregated_stats.zerocopy_bytes << ", "
+                           << "\n\tRegular Sends: " << aggregated_stats.regular_sends << ", "
+                           << "\n\tRegular Bytes: " << aggregated_stats.regular_bytes << ", "
+                           << "\n\tCoordination Fallbacks: " << aggregated_stats.coordination_fallbacks << ", "
+                           << "\n\tPending Async Operations: " << aggregated_stats.pending_async_operations << ", "
+                           << "\n\tOutstanding ZC Buffers: " << aggregated_stats.outstanding_zerocopy_buffers << ", "
+                           << "\n\tCompletion Notifications: " << aggregated_stats.completion_notifications_received << ", "
+                           << "\n\tMissing Notifications: " << aggregated_stats.completion_notifications_missing << ", "
+                           << std::fixed << std::setprecision(2)
+                           << "\n\tZC Success Rate: " << aggregated_stats.zerocopy_percentage() << "%"
+                           << "\n\tCompletion Reliability: " << aggregated_stats.completion_reliability() << "%\n";
+        
+        // Reset stats after reporting for all sessions
+        for (const auto& s : sessions_) {
+            if (auto session = s.lock()) {
+                if (auto zc_session = dynamic_cast<StreamSessionTcpCoordinated*>(session.get())) {
+                    zc_session->resetZeroCopyStats();
+                }
+            }
+        }
+        
+        // Reset the flag for next reporting cycle
+        std::thread([]{
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            already_printed = false;
+        }).detach();
+    }
+}
+
+void StreamServer::startDiagnosticsTimer()
+{
+    diagnostics_timer_.expires_after(std::chrono::seconds(30));
+    diagnostics_timer_.async_wait([this](boost::system::error_code ec)
+    {
+        if (ec)
+            return;
+        
+        // Only print diagnostics if there are active sessions
+        {
+            std::lock_guard<std::recursive_mutex> mlock(sessionsMutex_);
+            if (!sessions_.empty())
+            {
+                for (const auto& s : sessions_)
+                {
+                    if (auto session = s.lock())
+                    {
+                        // Handle zerocopy diagnostics
+                        if (auto coordinated_session = std::dynamic_pointer_cast<StreamSessionTcpCoordinated>(session))
+                        {
+                            LOG(INFO, LOG_TAG) << "=== Periodic ZeroCopy Status (every 30s) ===\n";
+                            printZeroCopyDiagnostics(coordinated_session.get());
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Schedule next diagnostics check
+        startDiagnosticsTimer();
+    });
 }

--- a/server/stream_server.hpp
+++ b/server/stream_server.hpp
@@ -25,6 +25,7 @@
 #include "control_server.hpp"
 #include "server_settings.hpp"
 #include "stream_session.hpp"
+#include "stream_session_tcp_coordinated.hpp"
 
 // 3rd party headers
 #include <boost/asio/io_context.hpp>
@@ -75,11 +76,17 @@ public:
     session_ptr getStreamSession(const std::string& clientId) const;
     /// @return stream session for @p session
     session_ptr getStreamSession(StreamSession* session) const;
+    
+    /// Print zerocopy diagnostics for all sessions
+    void printZeroCopyDiagnostics(StreamSessionTcpCoordinated* coordinated_session) const;
 
 private:
     void startAccept();
     void handleAccept(tcp::socket socket);
     void cleanup();
+    
+    /// Start periodic diagnostics timer
+    void startDiagnosticsTimer();
 
     /// Implementation of StreamMessageReceiver
     void onMessageReceived(const std::shared_ptr<StreamSession>& streamSession, const msg::BaseMessage& baseMessage, char* buffer) override;
@@ -90,6 +97,7 @@ private:
     boost::asio::io_context& io_context_;
     std::vector<acceptor_ptr> acceptor_;
     boost::asio::steady_timer config_timer_;
+    boost::asio::steady_timer diagnostics_timer_;
 
     ServerSettings settings_;
     Queue<std::shared_ptr<msg::BaseMessage>> messages_;

--- a/server/stream_server.hpp
+++ b/server/stream_server.hpp
@@ -91,7 +91,7 @@ private:
     void startAccept();
     void handleAccept(tcp::socket socket);
     void cleanup();
-    
+
     /// Start periodic diagnostics timer
     void startDiagnosticsTimer();
 

--- a/server/stream_server.hpp
+++ b/server/stream_server.hpp
@@ -25,7 +25,12 @@
 #include "control_server.hpp"
 #include "server_settings.hpp"
 #include "stream_session.hpp"
+#ifdef __linux__
 #include "stream_session_tcp_coordinated.hpp"
+#else
+// Forward declaration for non-Linux platforms
+class StreamSessionTcpCoordinated;
+#endif
 
 // 3rd party headers
 #include <boost/asio/io_context.hpp>
@@ -76,9 +81,11 @@ public:
     session_ptr getStreamSession(const std::string& clientId) const;
     /// @return stream session for @p session
     session_ptr getStreamSession(StreamSession* session) const;
-    
+
+#ifdef __linux__
     /// Print zerocopy diagnostics for all sessions
     void printZeroCopyDiagnostics(StreamSessionTcpCoordinated* coordinated_session) const;
+#endif
 
 private:
     void startAccept();

--- a/server/stream_session.cpp
+++ b/server/stream_session.cpp
@@ -64,8 +64,8 @@ void StreamSession::sendNext()
     {
         // CRITICAL: Convert to shared_ptr for safe zerocopy buffer lifetime
         auto buffer_ptr = std::make_shared<shared_const_buffer>(buffer);
-        
-        // Pass shared_ptr to sendAsync - buffer now guaranteed to live 
+
+        // Pass shared_ptr to sendAsync - buffer now guaranteed to live
         // until kernel completion notification
         sendAsync(buffer_ptr, [this, buffer_ptr](boost::system::error_code ec, std::size_t length)
         {

--- a/server/stream_session.hpp
+++ b/server/stream_session.hpp
@@ -162,7 +162,7 @@ public:
 
 protected:
     /// Send data @p buffer to the streaming client, result is returned in the callback @p handler
-    virtual void sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler) = 0;
+    virtual void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) = 0;
 
 public:
     /// Sends a message to the client (asynchronous)

--- a/server/stream_session_tcp.cpp
+++ b/server/stream_session_tcp.cpp
@@ -135,9 +135,9 @@ void StreamSessionTcp::readNext()
 }
 
 
-void StreamSessionTcp::sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler)
+void StreamSessionTcp::sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
 {
-    boost::asio::async_write(socket_, buffer,
+    boost::asio::async_write(socket_, *buffer,
                              [self = shared_from_this(), buffer, handler = std::move(handler)](boost::system::error_code ec, std::size_t length)
     {
         if (handler)

--- a/server/stream_session_tcp.hpp
+++ b/server/stream_session_tcp.hpp
@@ -50,8 +50,7 @@ protected:
     /// Read next message
     void readNext();
     /// Send message @p buffer and pass result to @p handler
-    void sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler) override;
-
-private:
+    void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
+    
     tcp::socket socket_;
 };

--- a/server/stream_session_tcp.hpp
+++ b/server/stream_session_tcp.hpp
@@ -51,7 +51,7 @@ protected:
     void readNext();
     /// Send message @p buffer and pass result to @p handler
     void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
-    
+
     /// Socket for this TCP session
     tcp::socket socket_;
 };

--- a/server/stream_session_tcp.hpp
+++ b/server/stream_session_tcp.hpp
@@ -52,5 +52,6 @@ protected:
     /// Send message @p buffer and pass result to @p handler
     void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
     
+    /// Socket for this TCP session
     tcp::socket socket_;
 };

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -1,0 +1,495 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2025  aanno <aannoaanno@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+// prototype/interface header file
+#include "stream_session_tcp_coordinated.hpp"
+
+// local headers
+#include "common/aixlog.hpp"
+
+// standard headers
+#include <linux/errqueue.h>
+#include <linux/net_tstamp.h>
+#include <cstring>
+#include <pthread.h>
+
+// MSG_ZEROCOPY definition for compatibility with older headers
+#ifndef MSG_ZEROCOPY
+#define MSG_ZEROCOPY 0x4000000
+#endif
+
+static constexpr auto LOG_TAG = "StreamSessionTcpCoordinated";
+static constexpr auto LOG_TAG_COMPLETION = "ZeroCopyCompletion";
+static constexpr auto LOG_TAG_STATS = "ZeroCopyStats";
+
+// Removed global buffer registry - now using per-socket shared_ptr tracking
+
+StreamSessionTcpCoordinated::StreamSessionTcpCoordinated(StreamMessageReceiver* receiver, const ServerSettings& server_settings, tcp::socket&& socket)
+    : StreamSessionTcp(receiver, server_settings, std::move(socket))
+{
+    native_socket_ = socket_.native_handle();
+    LOG(DEBUG, LOG_TAG) << "Native socket handle: " << native_socket_ << "\n";
+    zerocopy_available_ = initializeZeroCopy();
+    
+    if (zerocopy_available_)
+    {
+        LOG(INFO, LOG_TAG) << "Coordinated ZeroCopy enabled for session " << getIP() << "\n";
+    }
+    else
+    {
+        LOG(INFO, LOG_TAG) << "ZeroCopy not available for session " << getIP() << ", using regular TCP\n";
+    }
+}
+
+StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
+{
+    stop();
+    
+    // Log final statistics
+    if (zerocopy_available_)
+    {
+        auto stats = getZeroCopyStats();
+        LOG(INFO, LOG_TAG) << "Session " << getIP() << " final stats - ZC: " << stats.zerocopy_successful 
+                           << "/" << stats.zerocopy_attempts << " (" << stats.zerocopy_percentage() << "%), "
+                           << "Regular: " << stats.regular_sends << ", Fallbacks: " << stats.coordination_fallbacks << "\n";
+    }
+}
+
+void StreamSessionTcpCoordinated::start()
+{
+    StreamSessionTcp::start();
+    
+    if (zerocopy_available_)
+    {
+        startErrorQueueMonitoring();
+    }
+}
+
+void StreamSessionTcpCoordinated::stop()
+{
+    if (zerocopy_available_)
+    {
+        stopErrorQueueMonitoring();
+        
+        // Clear any pending sends
+        std::lock_guard<std::mutex> lock(pending_sends_mutex_);
+        while (!pending_sends_.empty())
+        {
+            auto& pending = pending_sends_.front();
+            if (pending.handler)
+            {
+                pending.handler(boost::asio::error::operation_aborted, 0);
+            }
+            pending_sends_.pop();
+        }
+    }
+    
+    StreamSessionTcp::stop();
+
+
+}
+
+bool StreamSessionTcpCoordinated::initializeZeroCopy()
+{
+    // LOG(DEBUG, LOG_TAG) << "initializeZeroCopy called with native_socket_: " << native_socket_ << "\n";
+    if (native_socket_ < 0)
+    {
+        LOG(WARNING, LOG_TAG) << "Invalid native socket handle: " << native_socket_ << "\n";
+        return false;
+    }
+    
+    // Enable zerocopy on socket
+    int enable = 1;
+    if (setsockopt(native_socket_, SOL_SOCKET, SO_ZEROCOPY, &enable, sizeof(enable)) < 0)
+    {
+        LOG(WARNING, LOG_TAG) << "Failed to enable SO_ZEROCOPY: " << strerror(errno) << "\n";
+        return false;
+    }
+    
+    // Verify zerocopy is enabled
+    int enabled = 0;
+    socklen_t len = sizeof(enabled);
+    if (getsockopt(native_socket_, SOL_SOCKET, SO_ZEROCOPY, &enabled, &len) < 0 || !enabled)
+    {
+        LOG(WARNING, LOG_TAG) << "SO_ZEROCOPY verification failed\n";
+        return false;
+    }
+    
+    LOG(DEBUG, LOG_TAG) << "Coordinated ZeroCopy successfully enabled on socket\n";
+    return true;
+}
+
+bool StreamSessionTcpCoordinated::tryReserveZeroCopy()
+{
+    // Atomically check if idle and reserve for zerocopy (race-condition safe)
+    uint32_t expected = 0;
+    while (!pending_async_operations_.compare_exchange_weak(expected, 1))
+    {
+        if (expected != 0)
+        {
+            // Another operation is in progress; cannot do zerocopy now
+            return false;
+        }
+        // If spurious failure, 'expected' is reloaded with current value, retry
+    }
+    return true; // Successfully reserved zerocopy
+}
+
+void StreamSessionTcpCoordinated::releaseZeroCopy()
+{
+    // Release zerocopy reservation
+    pending_async_operations_--;
+}
+
+void StreamSessionTcpCoordinated::sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
+{
+    size_t buffer_size = boost::asio::buffer_size(*buffer);
+    
+    // Decide whether to attempt zerocopy based on size and availability
+    bool should_use_zerocopy = zerocopy_available_ && 
+                              buffer_size >= ZEROCOPY_THRESHOLD &&
+                              tryReserveZeroCopy();
+    
+    if (should_use_zerocopy)
+    {
+        // LOG(TRACE, LOG_TAG) << "Attempting coordinated zerocopy send for " << buffer_size << " bytes\n";
+        sendZeroCopy(buffer, std::move(handler));
+    }
+    else
+    {
+        if (zerocopy_available_ && buffer_size >= ZEROCOPY_THRESHOLD)
+        {
+            coordination_fallbacks_++;
+            LOG(DEBUG, LOG_TAG) << "Zerocopy fallback due to pending async ops for " << buffer_size << " bytes\n";
+        }
+        sendRegularCoordinated(buffer, std::move(handler));
+    }
+}
+
+void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
+{
+    // Track the async operation
+    pending_async_operations_++;
+    regular_sends_++;
+    regular_bytes_ += boost::asio::buffer_size(*buffer);
+    
+    LOG(DEBUG, LOG_TAG_STATS) << "Regular send started, pending_async_operations now: " << pending_async_operations_.load() << "\n";
+    
+    // Use the parent class implementation with coordination tracking
+    StreamSessionTcp::sendAsync(buffer, [this, handler = std::move(handler)](boost::system::error_code ec, std::size_t bytes_transferred) mutable
+    {
+        // Decrement pending operations counter
+        pending_async_operations_--;
+        // LOG(DEBUG, LOG_TAG_STATS) << "Regular send completed, pending_async_operations now: " << pending_async_operations_.load() << "\n";
+        
+        // Call the original handler
+        if (handler)
+            handler(ec, bytes_transferred);
+        
+        // Process any queued sends that might now be able to use zerocopy
+        processPendingSends();
+    });
+}
+
+void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
+{
+    zerocopy_attempts_++;
+    
+    size_t buffer_size = boost::asio::buffer_size(*buffer);
+    
+    // Generate simple sequential buffer ID that matches kernel MSG_ZEROCOPY numbering
+    uint32_t buffer_id = next_buffer_id_++;
+    
+    // Prepare message header for sendmsg using the original buffer directly
+    struct msghdr msg = {};
+    
+    // Create iovec from the shared_const_buffer - no copying needed!
+    // Get the first boost::asio::const_buffer from the shared_const_buffer
+    auto const_buf = *buffer->begin();
+    const auto* data = boost::asio::buffer_cast<const void*>(const_buf);
+    struct iovec iov = {const_cast<void*>(data), buffer_size};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    
+    // Send with MSG_ZEROCOPY
+    // LOG(DEBUG, LOG_TAG) << "Attempting sendmsg with MSG_ZEROCOPY|MSG_DONTWAIT, buffer_size: " << buffer_size << "\n";
+    ssize_t result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
+    // LOG(TRACE, LOG_TAG) << "sendmsg result: " << result << ", errno: " << (result < 0 ? strerror(errno) : "success") << "\n";
+    
+    if (result < 0)
+    {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
+        {
+            LOG(WARNING, LOG_TAG) << "ZeroCopy send would block, falling back to regular send\n";
+            releaseZeroCopy(); // Release reservation before fallback
+            sendRegularCoordinated(buffer, std::move(handler));
+            return;
+        }
+        else
+        {
+            LOG(ERROR, LOG_TAG) << "ZeroCopy sendmsg failed: " << strerror(errno) << "\n";
+            releaseZeroCopy(); // Release reservation on error
+            if (handler)
+                handler(boost::system::error_code(errno, boost::system::system_category()), 0);
+            return;
+        }
+    }
+    
+    if (static_cast<size_t>(result) != buffer_size)
+    {
+        LOG(WARNING, LOG_TAG) << "ZeroCopy partial send: " << result << "/" << buffer_size << " bytes\n";
+        
+        // Track the partial zerocopy send - this IS a successful zerocopy operation
+        zerocopy_successful_++;
+        zerocopy_bytes_ += result;
+        outstanding_zerocopy_buffers_++;
+        
+        // Track the buffer for completion notification
+        {
+            std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
+            pending_zerocopy_buffers_[buffer_id] = buffer;
+        }
+        
+        // Send the unsent portion via regular send
+        size_t remaining_bytes = buffer_size - result;
+        // Create a sub-buffer for the remaining data
+        auto const_buf = *buffer->begin();
+        auto remaining_data = boost::asio::buffer_cast<const char*>(const_buf) + result;
+        auto remaining_buffer = std::make_shared<std::vector<char>>(remaining_data, remaining_data + remaining_bytes);
+        
+        LOG(INFO, LOG_TAG) << "Sending remaining " << remaining_bytes << " bytes via regular send\n";
+        releaseZeroCopy();
+        
+        // Send remaining data with shared_ptr to ensure buffer lifetime
+        boost::asio::async_write(socket_, boost::asio::buffer(*remaining_buffer),
+            [this, handler = std::move(handler), buffer_size, remaining_buffer](boost::system::error_code ec, std::size_t) mutable {
+            if (handler) {
+                handler(ec, ec ? 0 : buffer_size); // Report full size on success
+            }
+        });
+        return;
+    }
+    
+    // Success - zerocopy send completed immediately (synchronously from our perspective)
+    zerocopy_successful_++;
+    zerocopy_bytes_ += buffer_size;
+    outstanding_zerocopy_buffers_++;
+    
+    // Track the buffer for completion notification - shared_ptr keeps it alive
+    {
+        std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
+        pending_zerocopy_buffers_[buffer_id] = buffer;
+    }
+    
+    // LOG(TRACE, LOG_TAG) << "ZeroCopy send successful: " << buffer_size << " bytes, ID: " << buffer_id << ", tracking for completion\n";
+    
+    // Release zerocopy reservation
+    releaseZeroCopy();
+    
+    // Complete the handler immediately
+    if (handler)
+        handler(boost::system::error_code(), buffer_size);
+}
+
+void StreamSessionTcpCoordinated::processPendingSends()
+{
+    // Avoid recursive processing
+    if (processing_queue_.exchange(true))
+        return;
+    
+    std::lock_guard<std::mutex> lock(pending_sends_mutex_);
+    while (!pending_sends_.empty() && tryReserveZeroCopy())
+    {
+        auto pending = std::move(pending_sends_.front());
+        pending_sends_.pop();
+        
+        // Process this send now that we can use zerocopy
+        if (pending.use_zerocopy)
+        {
+            sendZeroCopy(pending.buffer, std::move(pending.handler));
+        }
+        else
+        {
+            sendRegularCoordinated(pending.buffer, std::move(pending.handler));
+        }
+    }
+    
+    processing_queue_.store(false);
+}
+
+void StreamSessionTcpCoordinated::startErrorQueueMonitoring()
+{
+    if (monitoring_active_.load())
+        return;
+    
+    monitoring_active_.store(true);
+    shutdown_requested_.store(false);
+    
+    LOG(DEBUG, LOG_TAG_COMPLETION) << "Starting error queue monitoring thread for session " << getIP() << "\n";
+    
+    // Launch dedicated thread for error queue monitoring
+    error_queue_thread_ = std::make_unique<std::thread>(&StreamSessionTcpCoordinated::errorQueueMonitoringLoop, this);
+}
+
+void StreamSessionTcpCoordinated::stopErrorQueueMonitoring()
+{
+    if (!monitoring_active_.load())
+        return;
+        
+    LOG(DEBUG, LOG_TAG_COMPLETION) << "Stopping error queue monitoring thread for session " << getIP() << "\n";
+    
+    shutdown_requested_.store(true);
+    monitoring_active_.store(false);
+    
+    // Wait for thread to complete
+    if (error_queue_thread_ && error_queue_thread_->joinable())
+    {
+        error_queue_thread_->join();
+        error_queue_thread_.reset();
+    }
+}
+
+void StreamSessionTcpCoordinated::errorQueueMonitoringLoop()
+{
+    // Set thread name for debugging (Linux-specific)
+    #ifdef __linux__
+    pthread_setname_np(pthread_self(), "zcopy-compl");
+    #endif
+    
+    // LOG(DEBUG, LOG_TAG_COMPLETION) << "Error queue monitoring thread started for session " << getIP() << "\n";
+    
+    while (monitoring_active_.load() && !shutdown_requested_.load())
+    {
+        processErrorQueue();
+        
+        // Sleep for 100ms between checks
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    
+    // LOG(DEBUG, LOG_TAG_COMPLETION) << "Error queue monitoring thread stopped for session " << getIP() << "\n";
+}
+
+void StreamSessionTcpCoordinated::processErrorQueue()
+{
+    // static int call_count = 0;
+    static int debug_call_count = 0;
+    char control_buf[512];
+    struct msghdr msg = {};
+    msg.msg_control = control_buf;
+    msg.msg_controllen = sizeof(control_buf);
+    
+    while (true)
+    {
+        /*
+        if (++call_count % 100 == 1) { // Log every 100th call to avoid spam
+            LOG(TRACE, LOG_TAG) << "Processing error queue (call #" << call_count << ")\n";
+        }*/
+        if (++debug_call_count % 1000 == 1) { // Log every 1000th call for proof it's running
+            LOG(DEBUG, LOG_TAG_COMPLETION) << "processErrorQueue() is active (call #" << debug_call_count << "), pending buffers: " << pending_zerocopy_buffers_.size() << "\n";
+        }
+
+        ssize_t ret = recvmsg(native_socket_, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
+        if (ret < 0)
+        {
+            if (errno != EAGAIN && errno != EWOULDBLOCK)
+            {
+                LOG(WARNING, LOG_TAG) << "Error queue recv failed: " << strerror(errno) << "\n";
+            }
+            break; // No more messages or error
+        }
+        
+        // LOG(TRACE, LOG_TAG) << "Received error queue message, size: " << ret << "\n";
+        
+        // Process control messages
+        for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg))
+        {
+            // LOG(TRACE, LOG_TAG) << "Control message: level=" << cmsg->cmsg_level << ", type=" << cmsg->cmsg_type << "\n";
+            if (cmsg->cmsg_level == SOL_IP && cmsg->cmsg_type == IP_RECVERR)
+            {
+                struct sock_extended_err* ee = reinterpret_cast<struct sock_extended_err*>(CMSG_DATA(cmsg));
+                if (ee->ee_errno == 0 && ee->ee_origin == SO_EE_ORIGIN_ZEROCOPY)
+                {
+                    // Zerocopy completion notification
+                    uint32_t lo = ee->ee_info;
+                    uint32_t hi = ee->ee_data;
+                    
+                    uint32_t buffers_in_range = hi - lo + 1;
+                    // LOG(TRACE, LOG_TAG_COMPLETION) << "ZeroCopy completion notification: range [" << lo << "-" << hi << "] (" << buffers_in_range << " buffers), tracking " << pending_zerocopy_buffers_.size() << " buffers\n";
+                    completion_notifications_received_++;
+                    buffers_completed_via_notifications_ += buffers_in_range;
+                    // LOG(TRACE, LOG_TAG_STATS) << "Added " << buffers_in_range << " completed buffers, total now: " << buffers_completed_via_notifications_.load() << "\n";
+                    
+                    // Release completed buffers - much simpler with shared_ptr!
+                    {
+                        std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
+                        for (uint32_t buffer_id = lo; buffer_id <= hi; ++buffer_id) {
+                            auto it = pending_zerocopy_buffers_.find(buffer_id);
+                            if (it != pending_zerocopy_buffers_.end()) {
+                                // LOG(TRACE, LOG_TAG) << "Completed zerocopy buffer ID " << buffer_id << ", shared_ptr will handle cleanup\n";
+                                
+                                // Remove from tracking - shared_ptr automatically handles cleanup
+                                pending_zerocopy_buffers_.erase(it);
+                                outstanding_zerocopy_buffers_--;
+                            } else {
+                                LOG(WARNING, LOG_TAG) << "Completion notification for unknown buffer ID " << buffer_id << "\n";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+StreamSessionTcpCoordinated::ZeroCopyStats StreamSessionTcpCoordinated::getZeroCopyStats() const
+{
+    ZeroCopyStats stats;
+    stats.zerocopy_attempts = zerocopy_attempts_.load();
+    stats.zerocopy_successful = zerocopy_successful_.load();
+    stats.zerocopy_bytes = zerocopy_bytes_.load();
+    stats.regular_sends = regular_sends_.load();
+    stats.regular_bytes = regular_bytes_.load();
+    stats.coordination_fallbacks = coordination_fallbacks_.load();
+    stats.pending_async_operations = pending_async_operations_.load();
+    stats.outstanding_zerocopy_buffers = outstanding_zerocopy_buffers_.load();
+    stats.completion_notifications_received = completion_notifications_received_.load();
+    stats.completion_notifications_missing = completion_notifications_missing_.load();
+    stats.buffers_completed_via_notifications = buffers_completed_via_notifications_.load();
+    
+    // Debug logging for problematic counters
+    LOG(DEBUG, LOG_TAG_STATS) << "Stats debug - buffers_completed=" << stats.buffers_completed_via_notifications
+                              << ", pending_async=" << stats.pending_async_operations  << "\n";
+    
+    return stats;
+}
+
+void StreamSessionTcpCoordinated::resetZeroCopyStats()
+{
+    zerocopy_attempts_.store(0);
+    zerocopy_successful_.store(0);
+    zerocopy_bytes_.store(0);
+    regular_sends_.store(0);
+    regular_bytes_.store(0);
+    coordination_fallbacks_.store(0);
+    completion_notifications_received_.store(0);
+    completion_notifications_missing_.store(0);
+    buffers_completed_via_notifications_.store(0);
+    // Note: outstanding_zerocopy_buffers, and pending_async_operations are not reset as they represent current state
+}
+
+// cleanupStaleBuffers() removed - shared_ptr handles cleanup automatically

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -209,101 +209,207 @@ void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<s
 void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
 {
     zerocopy_attempts_++;
-    
+
     size_t buffer_size = boost::asio::buffer_size(*buffer);
-    
+
     // Generate simple sequential buffer ID that matches kernel MSG_ZEROCOPY numbering
     uint32_t buffer_id = next_buffer_id_++;
-    
+
     // Prepare message header for sendmsg using the original buffer directly
     struct msghdr msg = {};
-    
-    // Create iovec from the shared_const_buffer - no copying needed!
-    // Get the first boost::asio::const_buffer from the shared_const_buffer
-    auto const_buf = *buffer->begin();
-    const auto* data = boost::asio::buffer_cast<const void*>(const_buf);
-    struct iovec iov = {const_cast<void*>(data), buffer_size};
-    msg.msg_iov = &iov;
-    msg.msg_iovlen = 1;
-    
-    // Send with MSG_ZEROCOPY
-    // LOG(DEBUG, LOG_TAG) << "Attempting sendmsg with MSG_ZEROCOPY|MSG_DONTWAIT, buffer_size: " << buffer_size << "\n";
+
+    // Build iovec vector from all const_buffer segments in the shared_const_buffer (no copies)
+    std::vector<iovec> iovs;
+    iovs.reserve(std::distance(buffer->begin(), buffer->end()));
+    for (auto const_buf : *buffer) {
+        const void* ptr = boost::asio::buffer_cast<const void*>(const_buf);
+        size_t len = boost::asio::buffer_size(const_buf);
+        iovs.push_back({ const_cast<void*>(ptr), static_cast<size_t>(len) });
+    }
+    msg.msg_iov = iovs.data();
+    msg.msg_iovlen = static_cast<int>(iovs.size());
+
+    // Single-shot sendmsg attempt
     ssize_t result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
-    // LOG(TRACE, LOG_TAG) << "sendmsg result: " << result << ", errno: " << (result < 0 ? strerror(errno) : "success") << "\n";
-    
+
+    // If it failed with transient "would block", do a small retry/backoff loop
+    auto is_would_block_err = [](int e) {
+        return e == EAGAIN || e == EWOULDBLOCK || e == ENOBUFS;
+    };
+
+    if (result < 0 && is_would_block_err(errno))
+    {
+        // limited retries with backoff (keeps blocking short and bounded)
+        const std::array<std::chrono::milliseconds, 3> backoffs = {
+            std::chrono::milliseconds(5),
+            std::chrono::milliseconds(20),
+            std::chrono::milliseconds(50)
+        };
+
+        for (size_t attempt = 0; attempt < backoffs.size(); ++attempt)
+        {
+            std::this_thread::sleep_for(backoffs[attempt]);
+            result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
+            if (result >= 0)
+                break;
+            if (result < 0 && !is_would_block_err(errno))
+                break; // fatal error, don't retry further
+        }
+    }
+
     if (result < 0)
     {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
+        if (is_would_block_err(errno))
         {
-            LOG(WARNING, LOG_TAG) << "ZeroCopy send would block, falling back to regular send\n";
-            releaseZeroCopy(); // Release reservation before fallback
+            LOG(WARNING, LOG_TAG) << "ZeroCopy send would block after retries, falling back to regular send\n";
+            // No zerocopy queued; release reservation and fallback
+            releaseZeroCopy();
             sendRegularCoordinated(buffer, std::move(handler));
             return;
         }
         else
         {
             LOG(ERROR, LOG_TAG) << "ZeroCopy sendmsg failed: " << strerror(errno) << "\n";
-            releaseZeroCopy(); // Release reservation on error
+            releaseZeroCopy();
             if (handler)
                 handler(boost::system::error_code(errno, boost::system::system_category()), 0);
             return;
         }
     }
-    
-    if (static_cast<size_t>(result) != buffer_size)
-    {
-        LOG(WARNING, LOG_TAG) << "ZeroCopy partial send: " << result << "/" << buffer_size << " bytes\n";
-        
-        // Track the partial zerocopy send - this IS a successful zerocopy operation
-        zerocopy_successful_++;
-        zerocopy_bytes_ += result;
-        outstanding_zerocopy_buffers_++;
-        
-        // Track the buffer for completion notification
-        {
-            std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
-            pending_zerocopy_buffers_[buffer_id] = buffer;
-        }
-        
-        // Send the unsent portion via regular send
-        size_t remaining_bytes = buffer_size - result;
-        // Create a sub-buffer for the remaining data
-        auto const_buf = *buffer->begin();
-        auto remaining_data = boost::asio::buffer_cast<const char*>(const_buf) + result;
-        auto remaining_buffer = std::make_shared<std::vector<char>>(remaining_data, remaining_data + remaining_bytes);
-        
-        LOG(INFO, LOG_TAG) << "Sending remaining " << remaining_bytes << " bytes via regular send\n";
-        releaseZeroCopy();
-        
-        // Send remaining data with shared_ptr to ensure buffer lifetime
-        boost::asio::async_write(socket_, boost::asio::buffer(*remaining_buffer),
-            [this, handler = std::move(handler), buffer_size, remaining_buffer](boost::system::error_code ec, std::size_t) mutable {
-            if (handler) {
-                handler(ec, ec ? 0 : buffer_size); // Report full size on success
-            }
-        });
-        return;
-    }
-    
-    // Success - zerocopy send completed immediately (synchronously from our perspective)
+
+    // At this point result >= 0: some bytes were queued
+    size_t sent_total = static_cast<size_t>(result);
+
+    // Track that kernel has queued at least part of the buffer
     zerocopy_successful_++;
-    zerocopy_bytes_ += buffer_size;
+    zerocopy_bytes_ += sent_total;
     outstanding_zerocopy_buffers_++;
-    
-    // Track the buffer for completion notification - shared_ptr keeps it alive
+
     {
         std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
         pending_zerocopy_buffers_[buffer_id] = buffer;
     }
-    
-    // LOG(TRACE, LOG_TAG) << "ZeroCopy send successful: " << buffer_size << " bytes, ID: " << buffer_id << ", tracking for completion\n";
-    
-    // Release zerocopy reservation
+
+    if (sent_total == buffer_size)
+    {
+        // Entire buffer queued via zerocopy
+        releaseZeroCopy();
+        if (handler)
+            handler(boost::system::error_code(), buffer_size);
+        return;
+    }
+
+    // Partial send: try to continue sending remaining bytes using iovecs that point
+    // into the original buffers. We do a bounded sequence of non-blocking attempts
+    // before falling back to an allocated copy + async_write.
+    size_t remaining = buffer_size - sent_total;
+
+    // Build remaining iovecs pointing into original iovs starting from offset 'sent_total'
+    auto build_remaining_iovs = [&](size_t already_sent) {
+        std::vector<iovec> rem;
+        rem.reserve(iovs.size());
+        size_t skip = already_sent;
+        for (const auto &iov : iovs) {
+            size_t len = static_cast<size_t>(iov.iov_len);
+            if (skip >= len) {
+                skip -= len;
+                continue;
+            }
+            char* base = static_cast<char*>(iov.iov_base) + skip;
+            rem.push_back({ base, static_cast<size_t>(len - skip) });
+            skip = 0;
+        }
+        return rem;
+    };
+
+    // Limited retry/backoff for remaining bytes
+    const std::array<std::chrono::milliseconds, 3> rem_backoffs = {
+        std::chrono::milliseconds(5),
+        std::chrono::milliseconds(20),
+        std::chrono::milliseconds(50)
+    };
+
+    size_t already_sent = sent_total;
+    bool rem_fully_queued = false;
+
+    for (size_t attempt = 0; attempt < rem_backoffs.size(); ++attempt)
+    {
+        std::vector<iovec> rem_iovs = build_remaining_iovs(already_sent);
+        msg.msg_iov = rem_iovs.data();
+        msg.msg_iovlen = static_cast<int>(rem_iovs.size());
+
+        // Try to send remaining portion
+        ssize_t rem_result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
+        if (rem_result >= 0)
+        {
+            already_sent += static_cast<size_t>(rem_result);
+            zerocopy_bytes_ += static_cast<size_t>(rem_result);
+            if (already_sent >= buffer_size)
+            {
+                rem_fully_queued = true;
+                break;
+            }
+            // If still partial, sleep and retry
+            std::this_thread::sleep_for(rem_backoffs[attempt]);
+            continue;
+        }
+        else if (is_would_block_err(errno))
+        {
+            // wait and retry
+            std::this_thread::sleep_for(rem_backoffs[attempt]);
+            continue;
+        }
+        else
+        {
+            // fatal error from sendmsg
+            LOG(ERROR, LOG_TAG) << "ZeroCopy continued send failed: " << strerror(errno) << "\n";
+            break;
+        }
+    }
+
+    if (rem_fully_queued)
+    {
+        // All bytes successfully queued via zerocopy after retries
+        releaseZeroCopy();
+        if (handler)
+            handler(boost::system::error_code(), buffer_size);
+        return;
+    }
+
+    // Still some bytes remain after retries -> fall back to copying the remaining bytes
+    size_t still_remaining = buffer_size - already_sent;
+    LOG(WARNING, LOG_TAG) << "ZeroCopy partial send unresolved after retries, falling back for remaining "
+                          << still_remaining << " bytes\n";
+
     releaseZeroCopy();
-    
-    // Complete the handler immediately
-    if (handler)
-        handler(boost::system::error_code(), buffer_size);
+
+    // Build contiguous copy of the remaining tail (only now we allocate)
+    auto remaining_vec = std::make_shared<std::vector<char>>();
+    remaining_vec->reserve(still_remaining);
+
+    size_t to_skip = already_sent;
+    for (auto const_buf : *buffer) {
+        size_t len = boost::asio::buffer_size(const_buf);
+        const char* data = boost::asio::buffer_cast<const char*>(const_buf);
+        if (to_skip >= len) {
+            to_skip -= len;
+            continue;
+        }
+        size_t off = to_skip;
+        size_t take = std::min(len - off, still_remaining - remaining_vec->size());
+        remaining_vec->insert(remaining_vec->end(), data + off, data + off + take);
+        if (remaining_vec->size() == still_remaining) break;
+        to_skip = 0;
+    }
+
+    LOG(INFO, LOG_TAG) << "Sending remaining " << still_remaining << " bytes via regular send\n";
+
+    boost::asio::async_write(socket_, boost::asio::buffer(*remaining_vec),
+        [this, handler = std::move(handler), buffer_size, remaining_vec](boost::system::error_code ec, std::size_t) mutable {
+            if (handler) {
+                handler(ec, ec ? 0 : buffer_size); // report full logical size on success
+            }
+        });
 }
 
 void StreamSessionTcpCoordinated::processPendingSends()

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -417,7 +417,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     LOG(INFO, LOG_TAG) << "Sending remaining " << still_remaining << " bytes via regular send\n";
 
     boost::asio::async_write(socket_, boost::asio::buffer(*remaining_vec),
-        [this, handler = std::move(handler), buffer_size, remaining_vec](boost::system::error_code ec, std::size_t) mutable {
+        [handler = std::move(handler), buffer_size, remaining_vec](boost::system::error_code ec, std::size_t) mutable {
             if (handler) {
                 handler(ec, ec ? 0 : buffer_size); // report full logical size on success
             }

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -24,6 +24,7 @@
 
 // standard headers
 #include <array>
+#include <iomanip>
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>
 #include <cstring>
@@ -81,10 +82,11 @@ StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
 void StreamSessionTcpCoordinated::start()
 {
     StreamSessionTcp::start();
-    
+
     if (zerocopy_available_)
     {
         startErrorQueueMonitoring();
+        startPeriodicLogging();
     }
 }
 
@@ -97,6 +99,7 @@ void StreamSessionTcpCoordinated::finish()
 {
     if (zerocopy_available_)
     {
+        stopPeriodicLogging();
         stopErrorQueueMonitoring();
         
         // Clear any pending sends
@@ -611,6 +614,72 @@ void StreamSessionTcpCoordinated::resetZeroCopyStats()
     completion_notifications_missing_.store(0);
     buffers_completed_via_notifications_.store(0);
     // Note: outstanding_zerocopy_buffers, and pending_async_operations are not reset as they represent current state
+}
+
+void StreamSessionTcpCoordinated::startPeriodicLogging()
+{
+    if (stats_logging_active_.load())
+        return;
+
+    stats_logging_active_.store(true);
+
+    // Create timer using the socket's io_context
+    stats_timer_ = std::make_shared<boost::asio::steady_timer>(socket_.get_executor());
+
+    LOG(DEBUG, LOG_TAG_STATS) << "Starting periodic statistics logging for session " << getIP() << "\n";
+
+    scheduleNextLog();
+}
+
+void StreamSessionTcpCoordinated::stopPeriodicLogging()
+{
+    if (!stats_logging_active_.load())
+        return;
+
+    LOG(DEBUG, LOG_TAG_STATS) << "Stopping periodic statistics logging for session " << getIP() << "\n";
+
+    stats_logging_active_.store(false);
+
+    if (stats_timer_)
+    {
+        boost::system::error_code ec;
+        stats_timer_->cancel(ec);
+        stats_timer_.reset();
+    }
+}
+
+void StreamSessionTcpCoordinated::scheduleNextLog()
+{
+    if (!stats_logging_active_.load() || !stats_timer_)
+        return;
+
+    stats_timer_->expires_after(std::chrono::seconds(30));
+    stats_timer_->async_wait([this, self = shared_from_this()](const boost::system::error_code& ec)
+    {
+        if (ec || !stats_logging_active_.load())
+            return;
+
+        logStatistics();
+        scheduleNextLog();
+    });
+}
+
+void StreamSessionTcpCoordinated::logStatistics()
+{
+    auto stats = getZeroCopyStats();
+
+    LOG(INFO, LOG_TAG_STATS) << "=== ZeroCopy Status (session " << getIP() << ") ===\n"
+                             << "ZC Attempts: " << stats.zerocopy_attempts
+                             << ", ZC Successful: " << stats.zerocopy_successful
+                             << " (" << std::fixed << std::setprecision(2) << stats.zerocopy_percentage() << "%)"
+                             << ", ZC Bytes: " << stats.zerocopy_bytes << "\n"
+                             << "Regular Sends: " << stats.regular_sends
+                             << ", Regular Bytes: " << stats.regular_bytes
+                             << ", Coordination Fallbacks: " << stats.coordination_fallbacks << "\n"
+                             << "Outstanding ZC Buffers: " << stats.outstanding_zerocopy_buffers
+                             << ", Pending Async Ops: " << stats.pending_async_operations
+                             << ", Completion Reliability: " << std::fixed << std::setprecision(2)
+                             << stats.completion_reliability() << "%\n";
 }
 
 // cleanupStaleBuffers() removed - shared_ptr handles cleanup automatically

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -227,11 +227,16 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
 
     // Build iovec vector from all const_buffer segments in the shared_const_buffer (no copies)
     std::vector<iovec> iovs;
-    iovs.reserve(std::distance(buffer->begin(), buffer->end()));
-    for (auto const_buf : *buffer) {
-        const void* ptr = boost::asio::buffer_cast<const void*>(const_buf);
-        size_t len = boost::asio::buffer_size(const_buf);
-        iovs.push_back({ const_cast<void*>(ptr), static_cast<size_t>(len) });
+    // buffer->begin()/end() returns pointers to a single const_buffer in this implementation,
+    // but keep generic iteration for multi-segment buffers if present.
+    auto it_begin = buffer->begin();
+    auto it_end = buffer->end();
+    iovs.reserve(static_cast<size_t>(std::distance(it_begin, it_end)));
+    for (auto const_buf = it_begin; const_buf != it_end; ++const_buf) {
+        const boost::asio::const_buffer& cb = *const_buf;
+        const void* ptr = cb.data();
+        size_t len = static_cast<size_t>(cb.size());
+        iovs.push_back({ const_cast<void*>(ptr), len });
     }
     msg.msg_iov = iovs.data();
     msg.msg_iovlen = static_cast<int>(iovs.size());
@@ -394,9 +399,10 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     remaining_vec->reserve(still_remaining);
 
     size_t to_skip = already_sent;
-    for (auto const_buf : *buffer) {
-        size_t len = boost::asio::buffer_size(const_buf);
-        const char* data = boost::asio::buffer_cast<const char*>(const_buf);
+    for (auto const_buf = buffer->begin(); const_buf != buffer->end(); ++const_buf) {
+        const boost::asio::const_buffer& cb = *const_buf;
+        size_t len = static_cast<size_t>(cb.size());
+        const char* data = static_cast<const char*>(cb.data());
         if (to_skip >= len) {
             to_skip -= len;
             continue;
@@ -541,7 +547,7 @@ void StreamSessionTcpCoordinated::processErrorQueue()
                     uint32_t hi = ee->ee_data;
                     
                     uint32_t buffers_in_range = hi - lo + 1;
-                    // LOG(TRACE, LOG_TAG_COMPLETION) << "ZeroCopy completion notification: range [" << lo << "-" << hi << "] (" << buffers_in_range << " buffers), tracking " << pending_zerocopy_buffers_.size() << " buffers\n";
+                    // LOG(TRACE, LOG_TAG_COMPLETION) << "ZeroCopy completion notification: range [" << lo << "-" << hi << "] (" << buffers_in_range << " buffers), tracking " << pending_zerocopy_[...]
                     completion_notifications_received_++;
                     buffers_completed_via_notifications_ += buffers_in_range;
                     // LOG(TRACE, LOG_TAG_STATS) << "Added " << buffers_in_range << " completed buffers, total now: " << buffers_completed_via_notifications_.load() << "\n";

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -24,7 +24,6 @@
 
 // standard headers
 #include <array>
-#include <iomanip>
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>
 #include <cstring>
@@ -82,11 +81,10 @@ StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
 void StreamSessionTcpCoordinated::start()
 {
     StreamSessionTcp::start();
-
+    
     if (zerocopy_available_)
     {
         startErrorQueueMonitoring();
-        startPeriodicLogging();
     }
 }
 
@@ -99,7 +97,6 @@ void StreamSessionTcpCoordinated::finish()
 {
     if (zerocopy_available_)
     {
-        stopPeriodicLogging();
         stopErrorQueueMonitoring();
         
         // Clear any pending sends
@@ -614,72 +611,6 @@ void StreamSessionTcpCoordinated::resetZeroCopyStats()
     completion_notifications_missing_.store(0);
     buffers_completed_via_notifications_.store(0);
     // Note: outstanding_zerocopy_buffers, and pending_async_operations are not reset as they represent current state
-}
-
-void StreamSessionTcpCoordinated::startPeriodicLogging()
-{
-    if (stats_logging_active_.load())
-        return;
-
-    stats_logging_active_.store(true);
-
-    // Create timer using the socket's io_context
-    stats_timer_ = std::make_shared<boost::asio::steady_timer>(socket_.get_executor());
-
-    LOG(DEBUG, LOG_TAG_STATS) << "Starting periodic statistics logging for session " << getIP() << "\n";
-
-    scheduleNextLog();
-}
-
-void StreamSessionTcpCoordinated::stopPeriodicLogging()
-{
-    if (!stats_logging_active_.load())
-        return;
-
-    LOG(DEBUG, LOG_TAG_STATS) << "Stopping periodic statistics logging for session " << getIP() << "\n";
-
-    stats_logging_active_.store(false);
-
-    if (stats_timer_)
-    {
-        boost::system::error_code ec;
-        stats_timer_->cancel(ec);
-        stats_timer_.reset();
-    }
-}
-
-void StreamSessionTcpCoordinated::scheduleNextLog()
-{
-    if (!stats_logging_active_.load() || !stats_timer_)
-        return;
-
-    stats_timer_->expires_after(std::chrono::seconds(30));
-    stats_timer_->async_wait([this, self = shared_from_this()](const boost::system::error_code& ec)
-    {
-        if (ec || !stats_logging_active_.load())
-            return;
-
-        logStatistics();
-        scheduleNextLog();
-    });
-}
-
-void StreamSessionTcpCoordinated::logStatistics()
-{
-    auto stats = getZeroCopyStats();
-
-    LOG(INFO, LOG_TAG_STATS) << "=== ZeroCopy Status (session " << getIP() << ") ===\n"
-                             << "ZC Attempts: " << stats.zerocopy_attempts
-                             << ", ZC Successful: " << stats.zerocopy_successful
-                             << " (" << std::fixed << std::setprecision(2) << stats.zerocopy_percentage() << "%)"
-                             << ", ZC Bytes: " << stats.zerocopy_bytes << "\n"
-                             << "Regular Sends: " << stats.regular_sends
-                             << ", Regular Bytes: " << stats.regular_bytes
-                             << ", Coordination Fallbacks: " << stats.coordination_fallbacks << "\n"
-                             << "Outstanding ZC Buffers: " << stats.outstanding_zerocopy_buffers
-                             << ", Pending Async Ops: " << stats.pending_async_operations
-                             << ", Completion Reliability: " << std::fixed << std::setprecision(2)
-                             << stats.completion_reliability() << "%\n";
 }
 
 // cleanupStaleBuffers() removed - shared_ptr handles cleanup automatically

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -23,6 +23,7 @@
 #include "common/aixlog.hpp"
 
 // standard headers
+#include <array>
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>
 #include <cstring>
@@ -65,7 +66,7 @@ StreamSessionTcpCoordinated::StreamSessionTcpCoordinated(StreamMessageReceiver* 
 
 StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
 {
-    stop();
+    finish();
     
     // Log final statistics
     if (zerocopy_available_)
@@ -89,6 +90,11 @@ void StreamSessionTcpCoordinated::start()
 
 void StreamSessionTcpCoordinated::stop()
 {
+    finish();
+}
+
+void StreamSessionTcpCoordinated::finish()
+{
     if (zerocopy_available_)
     {
         stopErrorQueueMonitoring();
@@ -107,8 +113,6 @@ void StreamSessionTcpCoordinated::stop()
     }
     
     StreamSessionTcp::stop();
-
-
 }
 
 bool StreamSessionTcpCoordinated::initializeZeroCopy()
@@ -188,7 +192,7 @@ void StreamSessionTcpCoordinated::sendAsync(const std::shared_ptr<shared_const_b
     }
 }
 
-void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
+void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler)
 {
     // Track the async operation
     pending_async_operations_++;
@@ -213,7 +217,7 @@ void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<s
     });
 }
 
-void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
+void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler)
 {
     zerocopy_attempts_++;
 
@@ -235,7 +239,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     for (auto const_buf = it_begin; const_buf != it_end; ++const_buf) {
         const boost::asio::const_buffer& cb = *const_buf;
         const void* ptr = cb.data();
-        size_t len = static_cast<size_t>(cb.size());
+        auto len = static_cast<size_t>(cb.size());
         iovs.push_back({ const_cast<void*>(ptr), len });
     }
     msg.msg_iov = iovs.data();
@@ -258,9 +262,9 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
             std::chrono::milliseconds(50)
         };
 
-        for (size_t attempt = 0; attempt < backoffs.size(); ++attempt)
+        for (auto backoff : backoffs)
         {
-            std::this_thread::sleep_for(backoffs[attempt]);
+            std::this_thread::sleep_for(backoff);
             result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
             if (result >= 0)
                 break;
@@ -290,7 +294,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     }
 
     // At this point result >= 0: some bytes were queued
-    size_t sent_total = static_cast<size_t>(result);
+    auto sent_total = static_cast<size_t>(result);
 
     // Track that kernel has queued at least part of the buffer
     zerocopy_successful_++;
@@ -321,13 +325,13 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
         rem.reserve(iovs.size());
         size_t skip = already_sent;
         for (const auto &iov : iovs) {
-            size_t len = static_cast<size_t>(iov.iov_len);
+            auto len = static_cast<size_t>(iov.iov_len);
             if (skip >= len) {
                 skip -= len;
                 continue;
             }
             char* base = static_cast<char*>(iov.iov_base) + skip;
-            rem.push_back({ base, static_cast<size_t>(len - skip) });
+            rem.push_back({ base, len - skip });
             skip = 0;
         }
         return rem;
@@ -343,7 +347,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     size_t already_sent = sent_total;
     bool rem_fully_queued = false;
 
-    for (size_t attempt = 0; attempt < rem_backoffs.size(); ++attempt)
+    for (auto rem_backoff : rem_backoffs)
     {
         std::vector<iovec> rem_iovs = build_remaining_iovs(already_sent);
         msg.msg_iov = rem_iovs.data();
@@ -361,13 +365,13 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
                 break;
             }
             // If still partial, sleep and retry
-            std::this_thread::sleep_for(rem_backoffs[attempt]);
+            std::this_thread::sleep_for(rem_backoff);
             continue;
         }
         else if (is_would_block_err(errno))
         {
             // wait and retry
-            std::this_thread::sleep_for(rem_backoffs[attempt]);
+            std::this_thread::sleep_for(rem_backoff);
             continue;
         }
         else
@@ -401,7 +405,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     size_t to_skip = already_sent;
     for (auto const_buf = buffer->begin(); const_buf != buffer->end(); ++const_buf) {
         const boost::asio::const_buffer& cb = *const_buf;
-        size_t len = static_cast<size_t>(cb.size());
+        auto len = static_cast<size_t>(cb.size());
         const char* data = static_cast<const char*>(cb.data());
         if (to_skip >= len) {
             to_skip -= len;
@@ -506,9 +510,9 @@ void StreamSessionTcpCoordinated::processErrorQueue()
 {
     // static int call_count = 0;
     static int debug_call_count = 0;
-    char control_buf[512];
+    std::array<char, 512> control_buf = {};
     struct msghdr msg = {};
-    msg.msg_control = control_buf;
+    msg.msg_control = control_buf.data();
     msg.msg_controllen = sizeof(control_buf);
     
     while (true)
@@ -539,7 +543,7 @@ void StreamSessionTcpCoordinated::processErrorQueue()
             // LOG(TRACE, LOG_TAG) << "Control message: level=" << cmsg->cmsg_level << ", type=" << cmsg->cmsg_type << "\n";
             if (cmsg->cmsg_level == SOL_IP && cmsg->cmsg_type == IP_RECVERR)
             {
-                struct sock_extended_err* ee = reinterpret_cast<struct sock_extended_err*>(CMSG_DATA(cmsg));
+                auto ee = reinterpret_cast<struct sock_extended_err*>(CMSG_DATA(cmsg));
                 if (ee->ee_errno == 0 && ee->ee_origin == SO_EE_ORIGIN_ZEROCOPY)
                 {
                     // Zerocopy completion notification

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -24,9 +24,9 @@
 
 // standard headers
 #include <array>
+#include <cstring>
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>
-#include <cstring>
 #include <pthread.h>
 
 // msghdr, sendmsg
@@ -53,7 +53,7 @@ StreamSessionTcpCoordinated::StreamSessionTcpCoordinated(StreamMessageReceiver* 
     native_socket_ = socket_.native_handle();
     LOG(DEBUG, LOG_TAG) << "Native socket handle: " << native_socket_ << "\n";
     zerocopy_available_ = initializeZeroCopy();
-    
+
     if (zerocopy_available_)
     {
         LOG(INFO, LOG_TAG) << "Coordinated ZeroCopy enabled for session " << getIP() << "\n";
@@ -67,13 +67,13 @@ StreamSessionTcpCoordinated::StreamSessionTcpCoordinated(StreamMessageReceiver* 
 StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
 {
     finish();
-    
+
     // Log final statistics
     if (zerocopy_available_)
     {
         auto stats = getZeroCopyStats();
-        LOG(INFO, LOG_TAG) << "Session " << getIP() << " final stats - ZC: " << stats.zerocopy_successful 
-                           << "/" << stats.zerocopy_attempts << " (" << stats.zerocopy_percentage() << "%), "
+        LOG(INFO, LOG_TAG) << "Session " << getIP() << " final stats - ZC: " << stats.zerocopy_successful << "/" << stats.zerocopy_attempts << " ("
+                           << stats.zerocopy_percentage() << "%), "
                            << "Regular: " << stats.regular_sends << ", Fallbacks: " << stats.coordination_fallbacks << "\n";
     }
 }
@@ -81,7 +81,7 @@ StreamSessionTcpCoordinated::~StreamSessionTcpCoordinated()
 void StreamSessionTcpCoordinated::start()
 {
     StreamSessionTcp::start();
-    
+
     if (zerocopy_available_)
     {
         startErrorQueueMonitoring();
@@ -98,7 +98,7 @@ void StreamSessionTcpCoordinated::finish()
     if (zerocopy_available_)
     {
         stopErrorQueueMonitoring();
-        
+
         // Clear any pending sends
         std::lock_guard<std::mutex> lock(pending_sends_mutex_);
         while (!pending_sends_.empty())
@@ -111,7 +111,7 @@ void StreamSessionTcpCoordinated::finish()
             pending_sends_.pop();
         }
     }
-    
+
     StreamSessionTcp::stop();
 }
 
@@ -123,7 +123,7 @@ bool StreamSessionTcpCoordinated::initializeZeroCopy()
         LOG(WARNING, LOG_TAG) << "Invalid native socket handle: " << native_socket_ << "\n";
         return false;
     }
-    
+
     // Enable zerocopy on socket
     int enable = 1;
     if (setsockopt(native_socket_, SOL_SOCKET, SO_ZEROCOPY, &enable, sizeof(enable)) < 0)
@@ -131,7 +131,7 @@ bool StreamSessionTcpCoordinated::initializeZeroCopy()
         LOG(WARNING, LOG_TAG) << "Failed to enable SO_ZEROCOPY: " << strerror(errno) << "\n";
         return false;
     }
-    
+
     // Verify zerocopy is enabled
     int enabled = 0;
     socklen_t len = sizeof(enabled);
@@ -140,7 +140,7 @@ bool StreamSessionTcpCoordinated::initializeZeroCopy()
         LOG(WARNING, LOG_TAG) << "SO_ZEROCOPY verification failed\n";
         return false;
     }
-    
+
     LOG(DEBUG, LOG_TAG) << "Coordinated ZeroCopy successfully enabled on socket\n";
     return true;
 }
@@ -170,12 +170,10 @@ void StreamSessionTcpCoordinated::releaseZeroCopy()
 void StreamSessionTcpCoordinated::sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
 {
     size_t buffer_size = boost::asio::buffer_size(*buffer);
-    
+
     // Decide whether to attempt zerocopy based on size and availability
-    bool should_use_zerocopy = zerocopy_available_ && 
-                              buffer_size >= ZEROCOPY_THRESHOLD &&
-                              tryReserveZeroCopy();
-    
+    bool should_use_zerocopy = zerocopy_available_ && buffer_size >= ZEROCOPY_THRESHOLD && tryReserveZeroCopy();
+
     if (should_use_zerocopy)
     {
         // LOG(TRACE, LOG_TAG) << "Attempting coordinated zerocopy send for " << buffer_size << " bytes\n";
@@ -198,20 +196,20 @@ void StreamSessionTcpCoordinated::sendRegularCoordinated(const std::shared_ptr<s
     pending_async_operations_++;
     regular_sends_++;
     regular_bytes_ += boost::asio::buffer_size(*buffer);
-    
+
     LOG(DEBUG, LOG_TAG_STATS) << "Regular send started, pending_async_operations now: " << pending_async_operations_.load() << "\n";
-    
+
     // Use the parent class implementation with coordination tracking
     StreamSessionTcp::sendAsync(buffer, [this, handler = std::move(handler)](boost::system::error_code ec, std::size_t bytes_transferred) mutable
     {
         // Decrement pending operations counter
         pending_async_operations_--;
         // LOG(DEBUG, LOG_TAG_STATS) << "Regular send completed, pending_async_operations now: " << pending_async_operations_.load() << "\n";
-        
+
         // Call the original handler
         if (handler)
             handler(ec, bytes_transferred);
-        
+
         // Process any queued sends that might now be able to use zerocopy
         processPendingSends();
     });
@@ -236,11 +234,12 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     auto it_begin = buffer->begin();
     auto it_end = buffer->end();
     iovs.reserve(static_cast<size_t>(std::distance(it_begin, it_end)));
-    for (auto const_buf = it_begin; const_buf != it_end; ++const_buf) {
+    for (auto const_buf = it_begin; const_buf != it_end; ++const_buf)
+    {
         const boost::asio::const_buffer& cb = *const_buf;
         const void* ptr = cb.data();
         auto len = static_cast<size_t>(cb.size());
-        iovs.push_back({ const_cast<void*>(ptr), len });
+        iovs.push_back({const_cast<void*>(ptr), len});
     }
     msg.msg_iov = iovs.data();
     msg.msg_iovlen = static_cast<int>(iovs.size());
@@ -249,18 +248,12 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     ssize_t result = sendmsg(native_socket_, &msg, MSG_ZEROCOPY | MSG_DONTWAIT);
 
     // If it failed with transient "would block", do a small retry/backoff loop
-    auto is_would_block_err = [](int e) {
-        return e == EAGAIN || e == EWOULDBLOCK || e == ENOBUFS;
-    };
+    auto is_would_block_err = [](int e) { return e == EAGAIN || e == EWOULDBLOCK || e == ENOBUFS; };
 
     if (result < 0 && is_would_block_err(errno))
     {
         // limited retries with backoff (keeps blocking short and bounded)
-        const std::array<std::chrono::milliseconds, 3> backoffs = {
-            std::chrono::milliseconds(5),
-            std::chrono::milliseconds(20),
-            std::chrono::milliseconds(50)
-        };
+        const std::array<std::chrono::milliseconds, 3> backoffs = {std::chrono::milliseconds(5), std::chrono::milliseconds(20), std::chrono::milliseconds(50)};
 
         for (auto backoff : backoffs)
         {
@@ -320,29 +313,28 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     // before falling back to an allocated copy + async_write.
 
     // Build remaining iovecs pointing into original iovs starting from offset 'sent_total'
-    auto build_remaining_iovs = [&](size_t already_sent) {
+    auto build_remaining_iovs = [&](size_t already_sent)
+    {
         std::vector<iovec> rem;
         rem.reserve(iovs.size());
         size_t skip = already_sent;
-        for (const auto &iov : iovs) {
+        for (const auto& iov : iovs)
+        {
             auto len = static_cast<size_t>(iov.iov_len);
-            if (skip >= len) {
+            if (skip >= len)
+            {
                 skip -= len;
                 continue;
             }
             char* base = static_cast<char*>(iov.iov_base) + skip;
-            rem.push_back({ base, len - skip });
+            rem.push_back({base, len - skip});
             skip = 0;
         }
         return rem;
     };
 
     // Limited retry/backoff for remaining bytes
-    const std::array<std::chrono::milliseconds, 3> rem_backoffs = {
-        std::chrono::milliseconds(5),
-        std::chrono::milliseconds(20),
-        std::chrono::milliseconds(50)
-    };
+    const std::array<std::chrono::milliseconds, 3> rem_backoffs = {std::chrono::milliseconds(5), std::chrono::milliseconds(20), std::chrono::milliseconds(50)};
 
     size_t already_sent = sent_total;
     bool rem_fully_queued = false;
@@ -393,8 +385,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
 
     // Still some bytes remain after retries -> fall back to copying the remaining bytes
     size_t still_remaining = buffer_size - already_sent;
-    LOG(WARNING, LOG_TAG) << "ZeroCopy partial send unresolved after retries, falling back for remaining "
-                          << still_remaining << " bytes\n";
+    LOG(WARNING, LOG_TAG) << "ZeroCopy partial send unresolved after retries, falling back for remaining " << still_remaining << " bytes\n";
 
     releaseZeroCopy();
 
@@ -403,28 +394,33 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     remaining_vec->reserve(still_remaining);
 
     size_t to_skip = already_sent;
-    for (const auto& cb : *buffer) {
+    for (const auto& cb : *buffer)
+    {
         auto len = static_cast<size_t>(cb.size());
         const char* data = static_cast<const char*>(cb.data());
-        if (to_skip >= len) {
+        if (to_skip >= len)
+        {
             to_skip -= len;
             continue;
         }
         size_t off = to_skip;
         size_t take = std::min(len - off, still_remaining - remaining_vec->size());
         remaining_vec->insert(remaining_vec->end(), data + off, data + off + take);
-        if (remaining_vec->size() == still_remaining) break;
+        if (remaining_vec->size() == still_remaining)
+            break;
         to_skip = 0;
     }
 
     LOG(INFO, LOG_TAG) << "Sending remaining " << still_remaining << " bytes via regular send\n";
 
     boost::asio::async_write(socket_, boost::asio::buffer(*remaining_vec),
-        [handler = std::move(handler), buffer_size, remaining_vec](boost::system::error_code ec, std::size_t) mutable {
-            if (handler) {
-                handler(ec, ec ? 0 : buffer_size); // report full logical size on success
-            }
-        });
+                             [handler = std::move(handler), buffer_size, remaining_vec](boost::system::error_code ec, std::size_t) mutable
+    {
+        if (handler)
+        {
+            handler(ec, ec ? 0 : buffer_size); // report full logical size on success
+        }
+    });
 }
 
 void StreamSessionTcpCoordinated::processPendingSends()
@@ -432,13 +428,13 @@ void StreamSessionTcpCoordinated::processPendingSends()
     // Avoid recursive processing
     if (processing_queue_.exchange(true))
         return;
-    
+
     std::lock_guard<std::mutex> lock(pending_sends_mutex_);
     while (!pending_sends_.empty() && tryReserveZeroCopy())
     {
         auto pending = std::move(pending_sends_.front());
         pending_sends_.pop();
-        
+
         // Process this send now that we can use zerocopy
         if (pending.use_zerocopy)
         {
@@ -449,7 +445,7 @@ void StreamSessionTcpCoordinated::processPendingSends()
             sendRegularCoordinated(pending.buffer, std::move(pending.handler));
         }
     }
-    
+
     processing_queue_.store(false);
 }
 
@@ -457,12 +453,12 @@ void StreamSessionTcpCoordinated::startErrorQueueMonitoring()
 {
     if (monitoring_active_.load())
         return;
-    
+
     monitoring_active_.store(true);
     shutdown_requested_.store(false);
-    
+
     LOG(DEBUG, LOG_TAG_COMPLETION) << "Starting error queue monitoring thread for session " << getIP() << "\n";
-    
+
     // Launch dedicated thread for error queue monitoring
     error_queue_thread_ = std::make_unique<std::thread>(&StreamSessionTcpCoordinated::errorQueueMonitoringLoop, this);
 }
@@ -471,12 +467,12 @@ void StreamSessionTcpCoordinated::stopErrorQueueMonitoring()
 {
     if (!monitoring_active_.load())
         return;
-        
+
     LOG(DEBUG, LOG_TAG_COMPLETION) << "Stopping error queue monitoring thread for session " << getIP() << "\n";
-    
+
     shutdown_requested_.store(true);
     monitoring_active_.store(false);
-    
+
     // Wait for thread to complete
     if (error_queue_thread_ && error_queue_thread_->joinable())
     {
@@ -487,21 +483,21 @@ void StreamSessionTcpCoordinated::stopErrorQueueMonitoring()
 
 void StreamSessionTcpCoordinated::errorQueueMonitoringLoop()
 {
-    // Set thread name for debugging (Linux-specific)
-    #ifdef __linux__
+// Set thread name for debugging (Linux-specific)
+#ifdef __linux__
     pthread_setname_np(pthread_self(), "zcopy-compl");
-    #endif
-    
+#endif
+
     // LOG(DEBUG, LOG_TAG_COMPLETION) << "Error queue monitoring thread started for session " << getIP() << "\n";
-    
+
     while (monitoring_active_.load() && !shutdown_requested_.load())
     {
         processErrorQueue();
-        
+
         // Sleep for 100ms between checks
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    
+
     // LOG(DEBUG, LOG_TAG_COMPLETION) << "Error queue monitoring thread stopped for session " << getIP() << "\n";
 }
 
@@ -513,15 +509,17 @@ void StreamSessionTcpCoordinated::processErrorQueue()
     struct msghdr msg = {};
     msg.msg_control = control_buf.data();
     msg.msg_controllen = sizeof(control_buf);
-    
+
     while (true)
     {
         /*
         if (++call_count % 100 == 1) { // Log every 100th call to avoid spam
             LOG(TRACE, LOG_TAG) << "Processing error queue (call #" << call_count << ")\n";
         }*/
-        if (++debug_call_count % 1000 == 1) { // Log every 1000th call for proof it's running
-            LOG(DEBUG, LOG_TAG_COMPLETION) << "processErrorQueue() is active (call #" << debug_call_count << "), pending buffers: " << pending_zerocopy_buffers_.size() << "\n";
+        if (++debug_call_count % 1000 == 1)
+        { // Log every 1000th call for proof it's running
+            LOG(DEBUG, LOG_TAG_COMPLETION) << "processErrorQueue() is active (call #" << debug_call_count
+                                           << "), pending buffers: " << pending_zerocopy_buffers_.size() << "\n";
         }
 
         ssize_t ret = recvmsg(native_socket_, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
@@ -533,9 +531,9 @@ void StreamSessionTcpCoordinated::processErrorQueue()
             }
             break; // No more messages or error
         }
-        
+
         // LOG(TRACE, LOG_TAG) << "Received error queue message, size: " << ret << "\n";
-        
+
         // Process control messages
         for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg))
         {
@@ -548,25 +546,31 @@ void StreamSessionTcpCoordinated::processErrorQueue()
                     // Zerocopy completion notification
                     uint32_t lo = ee->ee_info;
                     uint32_t hi = ee->ee_data;
-                    
+
                     uint32_t buffers_in_range = hi - lo + 1;
-                    // LOG(TRACE, LOG_TAG_COMPLETION) << "ZeroCopy completion notification: range [" << lo << "-" << hi << "] (" << buffers_in_range << " buffers), tracking " << pending_zerocopy_[...]
+                    // LOG(TRACE, LOG_TAG_COMPLETION) << "ZeroCopy completion notification: range [" << lo << "-" << hi << "] (" << buffers_in_range << "
+                    // buffers), tracking " << pending_zerocopy_[...]
                     completion_notifications_received_++;
                     buffers_completed_via_notifications_ += buffers_in_range;
-                    // LOG(TRACE, LOG_TAG_STATS) << "Added " << buffers_in_range << " completed buffers, total now: " << buffers_completed_via_notifications_.load() << "\n";
-                    
+                    // LOG(TRACE, LOG_TAG_STATS) << "Added " << buffers_in_range << " completed buffers, total now: " <<
+                    // buffers_completed_via_notifications_.load() << "\n";
+
                     // Release completed buffers - much simpler with shared_ptr!
                     {
                         std::lock_guard<std::mutex> lock(zerocopy_buffers_mutex_);
-                        for (uint32_t buffer_id = lo; buffer_id <= hi; ++buffer_id) {
+                        for (uint32_t buffer_id = lo; buffer_id <= hi; ++buffer_id)
+                        {
                             auto it = pending_zerocopy_buffers_.find(buffer_id);
-                            if (it != pending_zerocopy_buffers_.end()) {
+                            if (it != pending_zerocopy_buffers_.end())
+                            {
                                 // LOG(TRACE, LOG_TAG) << "Completed zerocopy buffer ID " << buffer_id << ", shared_ptr will handle cleanup\n";
-                                
+
                                 // Remove from tracking - shared_ptr automatically handles cleanup
                                 pending_zerocopy_buffers_.erase(it);
                                 outstanding_zerocopy_buffers_--;
-                            } else {
+                            }
+                            else
+                            {
                                 LOG(WARNING, LOG_TAG) << "Completion notification for unknown buffer ID " << buffer_id << "\n";
                             }
                         }
@@ -591,11 +595,11 @@ StreamSessionTcpCoordinated::ZeroCopyStats StreamSessionTcpCoordinated::getZeroC
     stats.completion_notifications_received = completion_notifications_received_.load();
     stats.completion_notifications_missing = completion_notifications_missing_.load();
     stats.buffers_completed_via_notifications = buffers_completed_via_notifications_.load();
-    
+
     // Debug logging for problematic counters
     LOG(DEBUG, LOG_TAG_STATS) << "Stats debug - buffers_completed=" << stats.buffers_completed_via_notifications
-                              << ", pending_async=" << stats.pending_async_operations  << "\n";
-    
+                              << ", pending_async=" << stats.pending_async_operations << "\n";
+
     return stats;
 }
 

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -28,6 +28,13 @@
 #include <cstring>
 #include <pthread.h>
 
+// msghdr, sendmsg
+#include <sys/socket.h>
+// iovec
+#include <sys/uio.h>
+// buffer_cast, buffer_size
+#include <boost/asio/buffer.hpp>
+
 // MSG_ZEROCOPY definition for compatibility with older headers
 #ifndef MSG_ZEROCOPY
 #define MSG_ZEROCOPY 0x4000000
@@ -302,7 +309,6 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     // Partial send: try to continue sending remaining bytes using iovecs that point
     // into the original buffers. We do a bounded sequence of non-blocking attempts
     // before falling back to an allocated copy + async_write.
-    size_t remaining = buffer_size - sent_total;
 
     // Build remaining iovecs pointing into original iovs starting from offset 'sent_total'
     auto build_remaining_iovs = [&](size_t already_sent) {

--- a/server/stream_session_tcp_coordinated.cpp
+++ b/server/stream_session_tcp_coordinated.cpp
@@ -403,8 +403,7 @@ void StreamSessionTcpCoordinated::sendZeroCopy(const std::shared_ptr<shared_cons
     remaining_vec->reserve(still_remaining);
 
     size_t to_skip = already_sent;
-    for (auto const_buf = buffer->begin(); const_buf != buffer->end(); ++const_buf) {
-        const boost::asio::const_buffer& cb = *const_buf;
+    for (const auto& cb : *buffer) {
         auto len = static_cast<size_t>(cb.size());
         const char* data = static_cast<const char*>(cb.data());
         if (to_skip >= len) {

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -1,0 +1,165 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2025  aanno <aannoaanno@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+// local headers
+#include "stream_session_tcp.hpp"
+
+// 3rd party headers
+#include <boost/asio/steady_timer.hpp>
+
+// standard headers
+#include <atomic>
+#include <memory>
+#include <queue>
+#include <mutex>
+#include <unordered_map>
+#include <chrono>
+#include <thread>
+#include <sys/socket.h>
+#include <linux/errqueue.h>
+
+using boost::asio::ip::tcp;
+
+/// Coordinated TCP session with zerocopy when async operations are idle
+/**
+ * This session extends the regular TCP session with coordinated zerocopy capability.
+ * - Uses regular Boost.Asio async_write when there are pending operations
+ * - Uses direct MSG_ZEROCOPY sendmsg() only when socket is idle from Boost.Asio perspective
+ * - Maintains strict coordination to prevent mixing async and direct operations
+ * - Provides graceful fallback when zerocopy is not available
+ */
+class StreamSessionTcpCoordinated : public StreamSessionTcp
+{
+public:
+    StreamSessionTcpCoordinated(StreamMessageReceiver* receiver, const ServerSettings& server_settings, tcp::socket&& socket);
+    ~StreamSessionTcpCoordinated() override;
+
+    void start() override;
+    void stop() override;
+
+    /// Get zerocopy statistics for this session
+    struct ZeroCopyStats
+    {
+        uint64_t zerocopy_attempts{0};      // Total zerocopy send attempts
+        uint64_t zerocopy_successful{0};    // Successful zerocopy sends
+        uint64_t zerocopy_bytes{0};         // Total bytes sent via zerocopy
+        uint64_t regular_sends{0};          // Messages sent via regular async_write
+        uint64_t regular_bytes{0};          // Total bytes sent via regular async_write
+        uint64_t coordination_fallbacks{0}; // Fallbacks due to pending async ops
+        uint64_t pending_async_operations{0}; // Currently pending async_write operations
+        uint64_t outstanding_zerocopy_buffers{0}; // Buffers awaiting completion notifications
+        uint64_t completion_notifications_received{0}; // Completion notifications received
+        uint64_t completion_notifications_missing{0}; // Expected but missing notifications
+        uint64_t buffers_completed_via_notifications{0}; // Total buffers completed via notifications
+        uint64_t buffer_reuse_count{0}; // How many times buffers were reused
+        double zerocopy_percentage() const 
+        { 
+            return (zerocopy_attempts + regular_sends) > 0 ? 
+                   (double(zerocopy_successful) / double(zerocopy_attempts + regular_sends)) * 100.0 : 0.0; 
+        }
+        double completion_reliability() const 
+        {
+            return zerocopy_successful > 0 ? 
+                   (double(buffers_completed_via_notifications) / double(zerocopy_successful)) * 100.0 : 0.0;
+        }
+    };
+    
+    ZeroCopyStats getZeroCopyStats() const;
+    void resetZeroCopyStats();
+
+protected:
+    void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
+
+private:
+    /// Initialize zerocopy capability
+    bool initializeZeroCopy();
+    
+    /// Check if we can safely use zerocopy (no pending async operations)
+    bool canUseZeroCopy() const;
+    
+    /// Send using zerocopy (only when socket is idle)
+    void sendZeroCopy(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler);
+    
+    /// Send using regular async_write (coordinated with async operations)
+    void sendRegularCoordinated(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler);
+    
+    /// Process pending send queue
+    void processPendingSends();
+    
+    /// Try to reserve zerocopy access (thread-safe)
+    bool tryReserveZeroCopy();
+    
+    /// Release zerocopy reservation
+    void releaseZeroCopy();
+    
+    /// Error queue monitoring for zerocopy completions - thread-based
+    void startErrorQueueMonitoring();
+    void stopErrorQueueMonitoring();
+    void errorQueueMonitoringLoop();
+    void processErrorQueue();
+    
+    /// Simple buffer tracking for zerocopy completion
+    /// Maps buffer_id to the shared_ptr that keeps the buffer alive
+    /// When completion notification arrives, we remove the entry and let shared_ptr handle cleanup
+    
+    /// Pending send operation
+    struct PendingSend
+    {
+        std::shared_ptr<shared_const_buffer> buffer;
+        WriteHandler handler;
+        size_t size;
+        bool use_zerocopy;
+    };
+    
+    // Configuration
+    static constexpr size_t ZEROCOPY_THRESHOLD = 1024;  // Use zerocopy for messages >1KB
+    
+    // Zerocopy state
+    bool zerocopy_available_{false};
+    int native_socket_{-1};
+    std::atomic<uint32_t> next_buffer_id_{0};
+    
+    // Coordination state
+    std::atomic<uint32_t> pending_async_operations_{0};
+    std::queue<PendingSend> pending_sends_;
+    std::mutex pending_sends_mutex_;
+    std::atomic<bool> processing_queue_{false};
+    
+    // Statistics (thread-safe)
+    mutable std::atomic<uint64_t> zerocopy_attempts_{0};
+    mutable std::atomic<uint64_t> zerocopy_successful_{0};
+    mutable std::atomic<uint64_t> zerocopy_bytes_{0};
+    mutable std::atomic<uint64_t> regular_sends_{0};
+    mutable std::atomic<uint64_t> regular_bytes_{0};
+    mutable std::atomic<uint64_t> coordination_fallbacks_{0};
+    mutable std::atomic<uint64_t> outstanding_zerocopy_buffers_{0};
+    mutable std::atomic<uint64_t> completion_notifications_received_{0};
+    mutable std::atomic<uint64_t> completion_notifications_missing_{0};
+    mutable std::atomic<uint64_t> buffers_completed_via_notifications_{0};
+    
+    // Error queue monitoring - dedicated thread approach
+    std::unique_ptr<std::thread> error_queue_thread_;
+    std::atomic<bool> monitoring_active_{false};
+    std::atomic<bool> shutdown_requested_{false};
+    
+    // Buffer tracking - maps buffer_id to shared_ptr for completion handling
+    std::unordered_map<uint32_t, std::shared_ptr<shared_const_buffer>> pending_zerocopy_buffers_;
+    std::mutex zerocopy_buffers_mutex_;
+};

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -32,7 +32,12 @@
 #include <unordered_map>
 #include <chrono>
 #include <thread>
+// msghdr, sendmsg
 #include <sys/socket.h>
+// iovec
+#include <sys/uio.h>
+// buffer_cast, buffer_size
+#include <boost/asio/buffer.hpp>
 #include <linux/errqueue.h>
 
 using boost::asio::ip::tcp;

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -46,6 +46,7 @@ using boost::asio::ip::tcp;
 class StreamSessionTcpCoordinated : public StreamSessionTcp
 {
 public:
+    /// ctor. Received message from the client are passed to StreamMessageReceiver
     StreamSessionTcpCoordinated(StreamMessageReceiver* receiver, const ServerSettings& server_settings, tcp::socket&& socket);
     ~StreamSessionTcpCoordinated() override;
 
@@ -55,35 +56,39 @@ public:
     /// Get zerocopy statistics for this session
     struct ZeroCopyStats
     {
-        uint64_t zerocopy_attempts{0};      // Total zerocopy send attempts
-        uint64_t zerocopy_successful{0};    // Successful zerocopy sends
-        uint64_t zerocopy_bytes{0};         // Total bytes sent via zerocopy
-        uint64_t regular_sends{0};          // Messages sent via regular async_write
-        uint64_t regular_bytes{0};          // Total bytes sent via regular async_write
-        uint64_t coordination_fallbacks{0}; // Fallbacks due to pending async ops
-        uint64_t pending_async_operations{0}; // Currently pending async_write operations
-        uint64_t outstanding_zerocopy_buffers{0}; // Buffers awaiting completion notifications
-        uint64_t completion_notifications_received{0}; // Completion notifications received
-        uint64_t completion_notifications_missing{0}; // Expected but missing notifications
-        uint64_t buffers_completed_via_notifications{0}; // Total buffers completed via notifications
-        uint64_t buffer_reuse_count{0}; // How many times buffers were reused
+        uint64_t zerocopy_attempts{0};      ///< Total zerocopy send attempts
+        uint64_t zerocopy_successful{0};    ///< Successful zerocopy sends
+        uint64_t zerocopy_bytes{0};         ///< Total bytes sent via zerocopy
+        uint64_t regular_sends{0};          ///< Messages sent via regular async_write
+        uint64_t regular_bytes{0};          ///< Total bytes sent via regular async_write
+        uint64_t coordination_fallbacks{0}; ///< Fallbacks due to pending async ops
+        uint64_t pending_async_operations{0}; ///< Currently pending async_write operations
+        uint64_t outstanding_zerocopy_buffers{0}; ///< Buffers awaiting completion notifications
+        uint64_t completion_notifications_received{0}; ///< Completion notifications received
+        uint64_t completion_notifications_missing{0}; ///< Expected but missing notifications
+        uint64_t buffers_completed_via_notifications{0}; ///< Total buffers completed via notifications
+        uint64_t buffer_reuse_count{0}; ///< How many times buffers were reused
+        /// Calculate percentage of successful zerocopy sends
         double zerocopy_percentage() const 
         { 
             return (zerocopy_attempts + regular_sends) > 0 ? 
                    (double(zerocopy_successful) / double(zerocopy_attempts + regular_sends)) * 100.0 : 0.0; 
         }
+        /// Calculate completion reliability percentage
         double completion_reliability() const 
         {
             return zerocopy_successful > 0 ? 
                    (double(buffers_completed_via_notifications) / double(zerocopy_successful)) * 100.0 : 0.0;
         }
     };
-    
+    /// Retrieve zerocopy statistics
     ZeroCopyStats getZeroCopyStats() const;
+    /// Reset zerocopy statistics
     void resetZeroCopyStats();
 
 protected:
     void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
+    /// non-virtual version for stop()ing the StreamSession
     void finish();
 
 private:

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -84,6 +84,7 @@ public:
 
 protected:
     void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
+    void finish();
 
 private:
     /// Initialize zerocopy capability
@@ -93,10 +94,10 @@ private:
     bool canUseZeroCopy() const;
     
     /// Send using zerocopy (only when socket is idle)
-    void sendZeroCopy(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler);
+    void sendZeroCopy(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler);
     
     /// Send using regular async_write (coordinated with async operations)
-    void sendRegularCoordinated(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler);
+    void sendRegularCoordinated(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler);
     
     /// Process pending send queue
     void processPendingSends();

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -113,12 +113,6 @@ private:
     void stopErrorQueueMonitoring();
     void errorQueueMonitoringLoop();
     void processErrorQueue();
-
-    /// Periodic statistics logging
-    void startPeriodicLogging();
-    void stopPeriodicLogging();
-    void logStatistics();
-    void scheduleNextLog();
     
     /// Simple buffer tracking for zerocopy completion
     /// Maps buffer_id to the shared_ptr that keeps the buffer alive
@@ -163,12 +157,8 @@ private:
     std::unique_ptr<std::thread> error_queue_thread_;
     std::atomic<bool> monitoring_active_{false};
     std::atomic<bool> shutdown_requested_{false};
-
+    
     // Buffer tracking - maps buffer_id to shared_ptr for completion handling
     std::unordered_map<uint32_t, std::shared_ptr<shared_const_buffer>> pending_zerocopy_buffers_;
     std::mutex zerocopy_buffers_mutex_;
-
-    // Periodic statistics logging (every 30 seconds)
-    std::shared_ptr<boost::asio::steady_timer> stats_timer_;
-    std::atomic<bool> stats_logging_active_{false};
 };

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -32,12 +32,6 @@
 #include <unordered_map>
 #include <chrono>
 #include <thread>
-// msghdr, sendmsg
-#include <sys/socket.h>
-// iovec
-#include <sys/uio.h>
-// buffer_cast, buffer_size
-#include <boost/asio/buffer.hpp>
 #include <linux/errqueue.h>
 
 using boost::asio::ip::tcp;

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -32,7 +32,6 @@
 #include <unordered_map>
 #include <chrono>
 #include <thread>
-#include <linux/errqueue.h>
 
 using boost::asio::ip::tcp;
 

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -26,12 +26,12 @@
 
 // standard headers
 #include <atomic>
-#include <memory>
-#include <queue>
-#include <mutex>
-#include <unordered_map>
 #include <chrono>
+#include <memory>
+#include <mutex>
+#include <queue>
 #include <thread>
+#include <unordered_map>
 
 using boost::asio::ip::tcp;
 
@@ -56,29 +56,27 @@ public:
     /// Get zerocopy statistics for this session
     struct ZeroCopyStats
     {
-        uint64_t zerocopy_attempts{0};      ///< Total zerocopy send attempts
-        uint64_t zerocopy_successful{0};    ///< Successful zerocopy sends
-        uint64_t zerocopy_bytes{0};         ///< Total bytes sent via zerocopy
-        uint64_t regular_sends{0};          ///< Messages sent via regular async_write
-        uint64_t regular_bytes{0};          ///< Total bytes sent via regular async_write
-        uint64_t coordination_fallbacks{0}; ///< Fallbacks due to pending async ops
-        uint64_t pending_async_operations{0}; ///< Currently pending async_write operations
-        uint64_t outstanding_zerocopy_buffers{0}; ///< Buffers awaiting completion notifications
-        uint64_t completion_notifications_received{0}; ///< Completion notifications received
-        uint64_t completion_notifications_missing{0}; ///< Expected but missing notifications
+        uint64_t zerocopy_attempts{0};                   ///< Total zerocopy send attempts
+        uint64_t zerocopy_successful{0};                 ///< Successful zerocopy sends
+        uint64_t zerocopy_bytes{0};                      ///< Total bytes sent via zerocopy
+        uint64_t regular_sends{0};                       ///< Messages sent via regular async_write
+        uint64_t regular_bytes{0};                       ///< Total bytes sent via regular async_write
+        uint64_t coordination_fallbacks{0};              ///< Fallbacks due to pending async ops
+        uint64_t pending_async_operations{0};            ///< Currently pending async_write operations
+        uint64_t outstanding_zerocopy_buffers{0};        ///< Buffers awaiting completion notifications
+        uint64_t completion_notifications_received{0};   ///< Completion notifications received
+        uint64_t completion_notifications_missing{0};    ///< Expected but missing notifications
         uint64_t buffers_completed_via_notifications{0}; ///< Total buffers completed via notifications
-        uint64_t buffer_reuse_count{0}; ///< How many times buffers were reused
+        uint64_t buffer_reuse_count{0};                  ///< How many times buffers were reused
         /// Calculate percentage of successful zerocopy sends
-        double zerocopy_percentage() const 
-        { 
-            return (zerocopy_attempts + regular_sends) > 0 ? 
-                   (double(zerocopy_successful) / double(zerocopy_attempts + regular_sends)) * 100.0 : 0.0; 
+        double zerocopy_percentage() const
+        {
+            return (zerocopy_attempts + regular_sends) > 0 ? (double(zerocopy_successful) / double(zerocopy_attempts + regular_sends)) * 100.0 : 0.0;
         }
         /// Calculate completion reliability percentage
-        double completion_reliability() const 
+        double completion_reliability() const
         {
-            return zerocopy_successful > 0 ? 
-                   (double(buffers_completed_via_notifications) / double(zerocopy_successful)) * 100.0 : 0.0;
+            return zerocopy_successful > 0 ? (double(buffers_completed_via_notifications) / double(zerocopy_successful)) * 100.0 : 0.0;
         }
     };
     /// Retrieve zerocopy statistics
@@ -94,35 +92,35 @@ protected:
 private:
     /// Initialize zerocopy capability
     bool initializeZeroCopy();
-    
+
     /// Check if we can safely use zerocopy (no pending async operations)
     bool canUseZeroCopy() const;
-    
+
     /// Send using zerocopy (only when socket is idle)
     void sendZeroCopy(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler);
-    
+
     /// Send using regular async_write (coordinated with async operations)
     void sendRegularCoordinated(const std::shared_ptr<shared_const_buffer>& buffer, WriteHandler&& handler);
-    
+
     /// Process pending send queue
     void processPendingSends();
-    
+
     /// Try to reserve zerocopy access (thread-safe)
     bool tryReserveZeroCopy();
-    
+
     /// Release zerocopy reservation
     void releaseZeroCopy();
-    
+
     /// Error queue monitoring for zerocopy completions - thread-based
     void startErrorQueueMonitoring();
     void stopErrorQueueMonitoring();
     void errorQueueMonitoringLoop();
     void processErrorQueue();
-    
+
     /// Simple buffer tracking for zerocopy completion
     /// Maps buffer_id to the shared_ptr that keeps the buffer alive
     /// When completion notification arrives, we remove the entry and let shared_ptr handle cleanup
-    
+
     /// Pending send operation
     struct PendingSend
     {
@@ -131,21 +129,21 @@ private:
         size_t size;
         bool use_zerocopy;
     };
-    
+
     // Configuration
-    static constexpr size_t ZEROCOPY_THRESHOLD = 1024;  // Use zerocopy for messages >1KB
-    
+    static constexpr size_t ZEROCOPY_THRESHOLD = 1024; // Use zerocopy for messages >1KB
+
     // Zerocopy state
     bool zerocopy_available_{false};
     int native_socket_{-1};
     std::atomic<uint32_t> next_buffer_id_{0};
-    
+
     // Coordination state
     std::atomic<uint32_t> pending_async_operations_{0};
     std::queue<PendingSend> pending_sends_;
     std::mutex pending_sends_mutex_;
     std::atomic<bool> processing_queue_{false};
-    
+
     // Statistics (thread-safe)
     mutable std::atomic<uint64_t> zerocopy_attempts_{0};
     mutable std::atomic<uint64_t> zerocopy_successful_{0};
@@ -157,12 +155,12 @@ private:
     mutable std::atomic<uint64_t> completion_notifications_received_{0};
     mutable std::atomic<uint64_t> completion_notifications_missing_{0};
     mutable std::atomic<uint64_t> buffers_completed_via_notifications_{0};
-    
+
     // Error queue monitoring - dedicated thread approach
     std::unique_ptr<std::thread> error_queue_thread_;
     std::atomic<bool> monitoring_active_{false};
     std::atomic<bool> shutdown_requested_{false};
-    
+
     // Buffer tracking - maps buffer_id to shared_ptr for completion handling
     std::unordered_map<uint32_t, std::shared_ptr<shared_const_buffer>> pending_zerocopy_buffers_;
     std::mutex zerocopy_buffers_mutex_;

--- a/server/stream_session_tcp_coordinated.hpp
+++ b/server/stream_session_tcp_coordinated.hpp
@@ -113,6 +113,12 @@ private:
     void stopErrorQueueMonitoring();
     void errorQueueMonitoringLoop();
     void processErrorQueue();
+
+    /// Periodic statistics logging
+    void startPeriodicLogging();
+    void stopPeriodicLogging();
+    void logStatistics();
+    void scheduleNextLog();
     
     /// Simple buffer tracking for zerocopy completion
     /// Maps buffer_id to the shared_ptr that keeps the buffer alive
@@ -157,8 +163,12 @@ private:
     std::unique_ptr<std::thread> error_queue_thread_;
     std::atomic<bool> monitoring_active_{false};
     std::atomic<bool> shutdown_requested_{false};
-    
+
     // Buffer tracking - maps buffer_id to shared_ptr for completion handling
     std::unordered_map<uint32_t, std::shared_ptr<shared_const_buffer>> pending_zerocopy_buffers_;
     std::mutex zerocopy_buffers_mutex_;
+
+    // Periodic statistics logging (every 30 seconds)
+    std::shared_ptr<boost::asio::steady_timer> stats_timer_;
+    std::atomic<bool> stats_logging_active_{false};
 };

--- a/server/stream_session_ws.cpp
+++ b/server/stream_session_ws.cpp
@@ -134,13 +134,13 @@ std::string StreamSessionWebsocket::getIP()
 }
 
 
-void StreamSessionWebsocket::sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler)
+void StreamSessionWebsocket::sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler)
 {
-    LOG(TRACE, LOG_TAG) << "sendAsync: " << buffer.message().type << "\n";
+    LOG(TRACE, LOG_TAG) << "sendAsync: " << buffer->message().type << "\n";
 #ifdef HAS_OPENSSL
     if (is_ssl_)
     {
-        ssl_ws_->async_write(buffer, [self = shared_from_this(), buffer, handler = std::move(handler)](boost::system::error_code ec, std::size_t length)
+        ssl_ws_->async_write(*buffer, [self = shared_from_this(), buffer, handler = std::move(handler)](boost::system::error_code ec, std::size_t length)
         {
             if (handler)
                 handler(ec, length);
@@ -149,7 +149,7 @@ void StreamSessionWebsocket::sendAsync(const shared_const_buffer& buffer, WriteH
     else
 #endif
     {
-        tcp_ws_->async_write(buffer, [self = shared_from_this(), buffer, handler = std::move(handler)](boost::system::error_code ec, std::size_t length)
+        tcp_ws_->async_write(*buffer, [self = shared_from_this(), buffer, handler = std::move(handler)](boost::system::error_code ec, std::size_t length)
         {
             if (handler)
                 handler(ec, length);

--- a/server/stream_session_ws.hpp
+++ b/server/stream_session_ws.hpp
@@ -64,7 +64,7 @@ public:
 
 private:
     /// Send message @p buffer and pass result to @p handler
-    void sendAsync(const shared_const_buffer& buffer, WriteHandler&& handler) override;
+    void sendAsync(const std::shared_ptr<shared_const_buffer> buffer, WriteHandler&& handler) override;
     /// Read callback
     void on_read_ws(beast::error_code ec, std::size_t bytes_transferred);
     /// Read loop


### PR DESCRIPTION
This is an updated version of #1440 and hence an fix/enhancement for https://github.com/snapcast/snapcast/issues/1423

This is a zero copy implementation for TCP on linux (only).

I tackled the problem directly with sendmsg with MSG_ZEROCOPY and a dedicated thread for completion messages (MSG_ERRQUEUE). It's on an exclusive alternative path to the boost:asio stuff (as asio didn't support that) and it's linux only. But fallback is to the (alternative) asio implementation.

See #1440 for more details.