### PR TITLE
PR: In LOG, don't allocate strings and make string concatenations if log level is not recorded (updated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   BOOST_VERSION: 1_90_0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,17 @@ jobs:
         run: |
           brew update-if-needed
           brew install libsoxr flac libvorbis opus catch2 boost
+      - name: Export Homebrew env so CMake finds libs
+        run: |
+          BREW_PREFIX=$(brew --prefix)
+          echo "BREW_PREFIX=${BREW_PREFIX}"
+          export PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export LDFLAGS="-L${BREW_PREFIX}/lib ${LDFLAGS:-}"
+          export CPPFLAGS="-I${BREW_PREFIX}/include ${CPPFLAGS:-}"
+          # Optionally persist env for subsequent steps
+          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+          echo "LDFLAGS=${LDFLAGS}" >> $GITHUB_ENV
+          echo "CPPFLAGS=${CPPFLAGS}" >> $GITHUB_ENV
       - name: configure
         run: |
           cmake -S . -B build \

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES resampler.cpp sample_format.cpp base64.cpp stream_uri.cpp
-            utils/string_utils.cpp utils/file_utils.cpp)
+            utils/string_utils.cpp utils/file_utils.cpp aixlog.cpp)
 
 if(NOT WIN32 AND NOT ANDROID)
   list(APPEND SOURCES daemon.cpp)

--- a/common/aixlog.cpp
+++ b/common/aixlog.cpp
@@ -1,0 +1,186 @@
+/***
+      __   __  _  _  __     __    ___
+     / _\ (  )( \/ )(  )   /  \  / __)
+    /    \ )(  )  ( / (_/\(  O )( (_ \
+    \_/\_/(__)(_/\_)\____/ \__/  \___/
+    version 1.5.1
+    https://github.com/badaix/aixlog
+
+    This file is part of aixlog
+    Copyright (C) 2017-2025 Johannes Pohl
+
+    This software may be modified and distributed under the terms
+    of the MIT license.  See the LICENSE file for details.
+***/
+
+#include "aixlog.hpp"
+#include <unordered_map>
+
+namespace AixLog
+{
+
+/// Cache for should_log results to avoid repeated computations
+class ShouldLogCache
+{
+public:
+    /// @brief Key for the cache
+    struct CacheKey
+    {
+        int severity;
+        std::string tag;
+        
+        bool operator==(const CacheKey& other) const
+        {
+            return severity == other.severity && tag == other.tag;
+        }
+    };
+    
+    /// @brief Hash function for CacheKey
+    struct CacheKeyHash
+    {
+        std::size_t operator()(const CacheKey& key) const
+        {
+            return std::hash<int>()(key.severity) ^ 
+                   (std::hash<std::string>()(key.tag) << 1);
+        }
+    };
+    
+    /// @brief  Try to get from cache
+    bool getCached(SEVERITY severity, const char* tag, bool& result)
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        
+        CacheKey key{static_cast<int>(severity), tag ? std::string(tag) : std::string()};
+        auto it = cache_.find(key);
+        if (it != cache_.end())
+        {
+            result = it->second;
+            cache_hits_++;
+            return true;
+        }
+        cache_misses_++;
+        return false;
+    }
+    
+    /// @brief  Store in cache
+    void putCache(SEVERITY severity, const char* tag, bool result)
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        
+        CacheKey key{static_cast<int>(severity), tag ? std::string(tag) : std::string()};
+        cache_[key] = result;
+        
+        // Limit cache size to avoid memory growth
+        if (cache_.size() > MAX_CACHE_SIZE)
+        {
+            // Simple eviction: clear half the cache
+            auto it = cache_.begin();
+            std::advance(it, cache_.size() / 2);
+            cache_.erase(cache_.begin(), it);
+        }
+    }
+    
+    /// @brief Clear the cache
+    void clearCache()
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        cache_.clear();
+        cache_hits_ = 0;
+        cache_misses_ = 0;
+    }
+    
+    /// Debug stats
+    void getStats(size_t& hits, size_t& misses, size_t& size)
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        hits = cache_hits_;
+        misses = cache_misses_;
+        size = cache_.size();
+    }
+    
+private:
+    static constexpr size_t MAX_CACHE_SIZE = 1000;
+    std::unordered_map<CacheKey, bool, CacheKeyHash> cache_;
+    std::mutex cache_mutex_;
+    size_t cache_hits_{0};
+    size_t cache_misses_{0};
+};
+
+/// Global cache instance
+static ShouldLogCache& getShouldLogCache()
+{
+    static ShouldLogCache instance;
+    return instance;
+}
+
+/// Cached version of should_log
+bool Log::should_log_cached(SEVERITY severity, const char* tag)
+{
+    auto& cache = getShouldLogCache();
+    bool result;
+    
+    // Try cache first
+    if (cache.getCached(severity, tag, result))
+    {
+        return result;
+    }
+    
+    // Cache miss - compute result
+    Log& log = instance();
+    std::lock_guard<std::recursive_mutex> lock(log.mutex_);
+    
+    if (log.log_sinks_.empty())
+    {
+        result = true; // If no sinks configured, default to logging
+    }
+    else
+    {
+        // Convert old SEVERITY enum to new Severity enum
+        auto new_severity = static_cast<Severity>(severity);
+        
+        Metadata temp_metadata;
+        temp_metadata.severity = new_severity;
+        temp_metadata.tag = tag;
+        
+        result = false;
+        for (const auto& sink : log.log_sinks_)
+        {
+            if (sink->filter.match(temp_metadata))
+            {
+                result = true;
+                break;
+            }
+        }
+    }
+    
+    // Cache the result
+    cache.putCache(severity, tag, result);
+    
+    return result;
+}
+
+/// Overload for new Severity enum class
+bool Log::should_log_cached(Severity severity, const char* tag)
+{
+    return should_log_cached(static_cast<SEVERITY>(severity), tag);
+}
+
+/// Overload for new Severity enum class with std::string tag
+bool Log::should_log_cached(Severity severity, const std::string& tag)
+{
+    return should_log_cached(static_cast<SEVERITY>(severity), tag.c_str());
+}
+
+/// Clear cache when log configuration changes
+void Log::clearShouldLogCache()
+{
+    getShouldLogCache().clearCache();
+}
+
+/// Get cache statistics (for debugging)
+void Log::getShouldLogCacheStats(size_t& hits, size_t& misses, size_t& size)
+{
+    getShouldLogCache().getStats(hits, misses, size);
+}
+
+} // namespace AixLog

--- a/common/aixlog.cpp
+++ b/common/aixlog.cpp
@@ -3,7 +3,7 @@
      / _\ (  )( \/ )(  )   /  \  / __)
     /    \ )(  )  ( / (_/\(  O )( (_ \
     \_/\_/(__)(_/\_)\____/ \__/  \___/
-    version 1.5.1
+    version 1.6.0 - improved by aanno - but not header-only any more
     https://github.com/badaix/aixlog
 
     This file is part of aixlog
@@ -26,30 +26,33 @@ public:
     /// @brief Key for the cache
     struct CacheKey
     {
+        /// @brief Severity level
         int severity;
+        /// @brief Tag string
         std::string tag;
-        
+
+        /// @brief Equality operator
         bool operator==(const CacheKey& other) const
         {
             return severity == other.severity && tag == other.tag;
         }
     };
-    
+
     /// @brief Hash function for CacheKey
     struct CacheKeyHash
     {
+        /// @brief  Compute hash
         std::size_t operator()(const CacheKey& key) const
         {
-            return std::hash<int>()(key.severity) ^ 
-                   (std::hash<std::string>()(key.tag) << 1);
+            return std::hash<int>()(key.severity) ^ (std::hash<std::string>()(key.tag) << 1);
         }
     };
-    
+
     /// @brief  Try to get from cache
     bool getCached(SEVERITY severity, const char* tag, bool& result)
     {
         std::lock_guard<std::mutex> lock(cache_mutex_);
-        
+
         CacheKey key{static_cast<int>(severity), tag ? std::string(tag) : std::string()};
         auto it = cache_.find(key);
         if (it != cache_.end())
@@ -61,15 +64,15 @@ public:
         cache_misses_++;
         return false;
     }
-    
+
     /// @brief  Store in cache
     void putCache(SEVERITY severity, const char* tag, bool result)
     {
         std::lock_guard<std::mutex> lock(cache_mutex_);
-        
+
         CacheKey key{static_cast<int>(severity), tag ? std::string(tag) : std::string()};
         cache_[key] = result;
-        
+
         // Limit cache size to avoid memory growth
         if (cache_.size() > MAX_CACHE_SIZE)
         {
@@ -79,7 +82,7 @@ public:
             cache_.erase(cache_.begin(), it);
         }
     }
-    
+
     /// @brief Clear the cache
     void clearCache()
     {
@@ -88,7 +91,7 @@ public:
         cache_hits_ = 0;
         cache_misses_ = 0;
     }
-    
+
     /// Debug stats
     void getStats(size_t& hits, size_t& misses, size_t& size)
     {
@@ -97,7 +100,7 @@ public:
         misses = cache_misses_;
         size = cache_.size();
     }
-    
+
 private:
     static constexpr size_t MAX_CACHE_SIZE = 1000;
     std::unordered_map<CacheKey, bool, CacheKeyHash> cache_;
@@ -118,17 +121,17 @@ bool Log::should_log_cached(SEVERITY severity, const char* tag)
 {
     auto& cache = getShouldLogCache();
     bool result;
-    
+
     // Try cache first
     if (cache.getCached(severity, tag, result))
     {
         return result;
     }
-    
+
     // Cache miss - compute result
     Log& log = instance();
     std::lock_guard<std::recursive_mutex> lock(log.mutex_);
-    
+
     if (log.log_sinks_.empty())
     {
         result = true; // If no sinks configured, default to logging
@@ -137,11 +140,11 @@ bool Log::should_log_cached(SEVERITY severity, const char* tag)
     {
         // Convert old SEVERITY enum to new Severity enum
         auto new_severity = static_cast<Severity>(severity);
-        
+
         Metadata temp_metadata;
         temp_metadata.severity = new_severity;
         temp_metadata.tag = tag;
-        
+
         result = false;
         for (const auto& sink : log.log_sinks_)
         {
@@ -152,10 +155,10 @@ bool Log::should_log_cached(SEVERITY severity, const char* tag)
             }
         }
     }
-    
+
     // Cache the result
     cache.putCache(severity, tag, result);
-    
+
     return result;
 }
 

--- a/common/aixlog.cpp
+++ b/common/aixlog.cpp
@@ -116,6 +116,11 @@ static ShouldLogCache& getShouldLogCache()
     return instance;
 }
 
+// doxygen has problems with static functions inside cpp files and emits warning 
+// like "common/aixlog.cpp:166: warning: documented symbol 
+// 'bool AixLog::Log::should_log_cached' was not declared or defined."
+/// @cond INTERNAL
+
 /// Cached version of should_log
 bool Log::should_log_cached(SEVERITY severity, const char* tag)
 {
@@ -161,11 +166,6 @@ bool Log::should_log_cached(SEVERITY severity, const char* tag)
 
     return result;
 }
-
-// doxygen has problems with static functions inside cpp files and emits warning 
-// like "common/aixlog.cpp:166: warning: documented symbol 
-// 'bool AixLog::Log::should_log_cached' was not declared or defined."
-/// @cond INTERNAL
 
 /// Overload for new Severity enum class
 bool Log::should_log_cached(Severity severity, const char* tag)

--- a/common/aixlog.cpp
+++ b/common/aixlog.cpp
@@ -162,6 +162,11 @@ bool Log::should_log_cached(SEVERITY severity, const char* tag)
     return result;
 }
 
+// doxygen has problems with static functions inside cpp files and emits warning 
+// like "common/aixlog.cpp:166: warning: documented symbol 
+// 'bool AixLog::Log::should_log_cached' was not declared or defined."
+/// @cond INTERNAL
+
 /// Overload for new Severity enum class
 bool Log::should_log_cached(Severity severity, const char* tag)
 {
@@ -185,5 +190,7 @@ void Log::getShouldLogCacheStats(size_t& hits, size_t& misses, size_t& size)
 {
     getShouldLogCache().getStats(hits, misses, size);
 }
+
+/// @endcond
 
 } // namespace AixLog

--- a/common/aixlog.hpp
+++ b/common/aixlog.hpp
@@ -3,7 +3,7 @@
      / _\ (  )( \/ )(  )   /  \  / __)
     /    \ )(  )  ( / (_/\(  O )( (_ \
     \_/\_/(__)(_/\_)\____/ \__/  \___/
-    version 1.5.1
+    version 1.6.0 - improved by aanno - but not header-only any more
     https://github.com/badaix/aixlog
 
     This file is part of aixlog
@@ -103,33 +103,43 @@
 // usage: LOG(SEVERITY) or LOG(SEVERITY, TAG)
 // e.g.: LOG(NOTICE) or LOG(NOTICE, "my tag")
 // Helper for filtered-out log messages - inherit from ostream to ensure compatibility
-namespace AixLog {
-    class NullBuffer : public std::streambuf {
-    public:
-        int overflow(int c) override { return c; }
-    };
-    
-    class NullStream : public std::ostream {
-    public:
-        NullStream() : std::ostream(&buffer) {}
-    private:
-        NullBuffer buffer;
-    };
-    // Function to get null stream instance
-    inline NullStream& get_null_stream() {
-        static NullStream instance;
-        return instance;
+namespace AixLog
+{
+class NullBuffer : public std::streambuf
+{
+public:
+    int overflow(int c) override
+    {
+        return c;
     }
+};
+
+class NullStream : public std::ostream
+{
+public:
+    NullStream() : std::ostream(&buffer)
+    {
+    }
+
+private:
+    NullBuffer buffer;
+};
+// Function to get null stream instance
+inline NullStream& get_null_stream()
+{
+    static NullStream instance;
+    return instance;
 }
+} // namespace AixLog
 
 // LOG macro - optimization can be enabled by uncommenting the should_log check
 #ifndef WIN32
 // #define LOG(...) AIXLOG_INTERNAL__LOG_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__) << TIMESTAMP << FUNC
 /* Optimized version with caching */
-#define LOG(LEVEL, ...) \
-    (AixLog::Log::should_log_cached(LEVEL, ##__VA_ARGS__) ? \
-        (AIXLOG_INTERNAL__LOG_MACRO_CHOOSER(LEVEL, ##__VA_ARGS__)(LEVEL, ##__VA_ARGS__) << TIMESTAMP << FUNC) : \
-        AixLog::get_null_stream())
+#define LOG(LEVEL, ...)                                                                                                                                        \
+    (AixLog::Log::should_log_cached(LEVEL, ##__VA_ARGS__)                                                                                                      \
+         ? (AIXLOG_INTERNAL__LOG_MACRO_CHOOSER(LEVEL, ##__VA_ARGS__)(LEVEL, ##__VA_ARGS__) << TIMESTAMP << FUNC)                                               \
+         : AixLog::get_null_stream())
 #endif
 
 // usage: COLOR(TEXT_COLOR, BACKGROUND_COLOR) or COLOR(TEXT_COLOR)
@@ -605,16 +615,17 @@ public:
     {
         Log& log = instance();
         std::lock_guard<std::recursive_mutex> lock(log.mutex_);
-        
-        if (log.log_sinks_.empty()) return true; // If no sinks configured, default to logging
-        
+
+        if (log.log_sinks_.empty())
+            return true; // If no sinks configured, default to logging
+
         // Convert old SEVERITY enum to new Severity enum
         Severity new_severity = static_cast<Severity>(severity);
-        
+
         Metadata temp_metadata;
         temp_metadata.severity = new_severity;
         temp_metadata.tag = tag;
-        
+
         for (const auto& sink : log.log_sinks_)
         {
             if (sink->filter.match(temp_metadata))
@@ -628,13 +639,14 @@ public:
     {
         Log& log = instance();
         std::lock_guard<std::recursive_mutex> lock(log.mutex_);
-        
-        if (log.log_sinks_.empty()) return true; // If no sinks configured, default to logging
-        
+
+        if (log.log_sinks_.empty())
+            return true; // If no sinks configured, default to logging
+
         Metadata temp_metadata;
         temp_metadata.severity = severity;
         temp_metadata.tag = tag;
-        
+
         for (const auto& sink : log.log_sinks_)
         {
             if (sink->filter.match(temp_metadata))
@@ -645,16 +657,16 @@ public:
 
     /// Cached version of should_log for better performance (implemented in aixlog.cpp)
     static bool should_log_cached(SEVERITY severity, const char* tag = nullptr);
-    
+
     /// Cached version of should_log for new Severity enum class
     static bool should_log_cached(Severity severity, const char* tag = nullptr);
-    
+
     /// Cached version of should_log for new Severity enum class with std::string tag
     static bool should_log_cached(Severity severity, const std::string& tag);
-    
+
     /// Clear the should_log cache (call when log configuration changes)
     static void clearShouldLogCache();
-    
+
     /// Get cache statistics for debugging
     static void getShouldLogCacheStats(size_t& hits, size_t& misses, size_t& size);
 

--- a/common/time_defs.hpp
+++ b/common/time_defs.hpp
@@ -30,6 +30,7 @@
 #ifndef WINDOWS
 #include <sys/time.h>
 #else
+#define NOMINMAX
 #include <Windows.h>
 #include <stdint.h>
 #include <winsock2.h>

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -51,6 +51,7 @@
 #include <sys/system_properties.h>
 #endif
 #ifdef WINDOWS
+#define NOMINMAX
 #include <chrono>
 #include <direct.h>
 #include <iphlpapi.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,5 +36,11 @@ if(ANDROID)
   target_link_libraries(snapcast_test log)
 endif(ANDROID)
 
-target_link_libraries(snapcast_test OpenSSL::Crypto OpenSSL::SSL)
-target_link_libraries(snapcast_test Catch2::Catch2WithMain Catch2::Catch2)
+# Link against the common static library so AixLog (aixlog.cpp) and other common symbols are resolved.
+target_link_libraries(snapcast_test
+    common
+    OpenSSL::Crypto
+    OpenSSL::SSL
+    Catch2::Catch2WithMain
+    Catch2::Catch2
+)


### PR DESCRIPTION
This is an updated version of my PR #1439 

I did some profiling on snapcast (while working on #1423). From my measurements, I concluded that LOG currently allocates strings and makes string concatenations even if the log level at hand is not recorded.

Hence I tweaked aixlog.hpp to stop this. 

I also added an caching layer for the decision if a certain message is actually recorded, depending on the log level. However, with this caching layer, aixlog is no longer header only.