### PR TITLE
PR: dynamic buffer pool, used for server TCP for the moment (updated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   BOOST_VERSION: 1_90_0

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES resampler.cpp sample_format.cpp base64.cpp stream_uri.cpp
-            utils/string_utils.cpp utils/file_utils.cpp)
+            utils/string_utils.cpp utils/file_utils.cpp buffer_pool.cpp)
 
 if(NOT WIN32 AND NOT ANDROID)
   list(APPEND SOURCES daemon.cpp)

--- a/common/buffer_pool.cpp
+++ b/common/buffer_pool.cpp
@@ -1,0 +1,211 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+// prototype/interface header file
+#include "buffer_pool.hpp"
+
+// local headers
+#include "aixlog.hpp"
+
+// standard headers
+#include <algorithm>
+#include <map>
+
+static constexpr auto LOG_TAG = "BufferPool";
+
+DynamicBufferPool::DynamicBufferPool(size_t initial_count, size_t default_buffer_size)
+    : default_buffer_size_(std::max(default_buffer_size, MIN_BUFFER_SIZE))
+    , initial_count_(initial_count)
+    , last_cleanup_(std::chrono::steady_clock::now())
+{
+    // Lazy pre-allocation on first acquire
+    LOG(DEBUG, LOG_TAG) << "Initialized buffer pool (lazy) with default size " << default_buffer_size_ << "\n";
+}
+
+DynamicBufferPool::BufferGuard DynamicBufferPool::acquire(size_t min_size)
+{
+    check_cleanup();
+    
+    size_t target_size = std::max({min_size, default_buffer_size_, MIN_BUFFER_SIZE});
+    size_t size_bucket = get_size_bucket(target_size);
+    
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    // Lazy initial allocation
+    if (available_buffers_.empty() && initial_count_ > 0)
+    {
+        for (size_t i = 0; i < initial_count_; ++i)
+        {
+            auto buffer = create_buffer(default_buffer_size_);
+            available_buffers_[size_bucket].push_back(std::move(buffer));
+        }
+        initial_count_ = 0;  // Prevent repeated allocation
+    }
+    
+    // Try to reuse an existing buffer from the same or larger size bucket
+    auto it = available_buffers_.lower_bound(size_bucket);
+    while (it != available_buffers_.end())
+    {
+        if (!it->second.empty())
+        {
+            auto buffer = std::move(it->second.back());
+            it->second.pop_back();
+            
+            buffer->resize_if_needed(target_size);
+            ++buffers_reused_;
+            
+            LOG(TRACE, LOG_TAG) << "Reused buffer from size bucket " << it->first 
+                                << " for requested size " << target_size << "\n";
+            
+            return { *this, std::move(buffer) };
+        }
+        ++it;
+    }
+    
+    // No suitable buffer found, create a new one
+    auto buffer = create_buffer(target_size);
+    ++buffers_created_;
+    
+    LOG(TRACE, LOG_TAG) << "Created new buffer of size " << target_size << "\n";
+    
+    return { *this, std::move(buffer) };
+}
+
+void DynamicBufferPool::release(std::unique_ptr<Buffer> buffer)
+{
+    if (!buffer)
+        return;
+        
+    check_cleanup();
+    
+    size_t size_bucket = get_size_bucket(buffer->capacity);
+    
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    // Check if we have room in this size bucket
+    if (available_buffers_[size_bucket].size() < MAX_POOL_SIZE)
+    {
+        buffer->last_used = std::chrono::steady_clock::now();
+        available_buffers_[size_bucket].push_back(std::move(buffer));
+        
+        LOG(TRACE, LOG_TAG) << "Returned buffer to pool, size bucket " << size_bucket << "\n";
+    }
+    else
+    {
+        // Pool is full for this size, let buffer be destroyed
+        --total_buffers_;
+        bytes_allocated_ -= buffer->capacity;
+        
+        LOG(TRACE, LOG_TAG) << "Pool full for size bucket " << size_bucket 
+                            << ", destroying buffer\n";
+    }
+}
+
+std::unique_ptr<DynamicBufferPool::Buffer> DynamicBufferPool::create_buffer(size_t size)
+{
+    auto buffer = std::make_unique<Buffer>(size);
+    ++total_buffers_;
+    bytes_allocated_ += size;
+    return buffer;
+}
+
+size_t DynamicBufferPool::get_size_bucket(size_t size)
+{
+    // Round up to next power of 2 for bucketing
+    size_t bucket = MIN_BUFFER_SIZE;
+    while (bucket < size)
+        bucket *= GROWTH_FACTOR;
+    return bucket;
+}
+
+DynamicBufferPool::Stats DynamicBufferPool::getStats() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    Stats stats;
+    stats.total_buffers = total_buffers_;
+    stats.bytes_allocated = bytes_allocated_;
+    stats.buffers_created = buffers_created_;
+    stats.buffers_reused = buffers_reused_;
+    stats.cleanup_operations = cleanup_operations_;
+    
+    // Count available buffers
+    for (const auto& bucket : available_buffers_)
+    {
+        stats.available_buffers += bucket.second.size();
+    }
+    
+    return stats;
+}
+
+void DynamicBufferPool::resetStats()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffers_created_ = 0;
+    buffers_reused_ = 0;
+    cleanup_operations_ = 0;
+}
+
+void DynamicBufferPool::cleanup(std::chrono::seconds max_idle_time)
+{
+    auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_cleanup_ = now;
+    ++cleanup_operations_;
+    
+    size_t cleaned_count = 0;
+    
+    for (auto& bucket_pair : available_buffers_)
+    {
+        auto& deq = bucket_pair.second;
+        for (auto it = deq.begin(); it != deq.end(); )
+        {
+            if (now - (*it)->last_used >= max_idle_time)
+            {
+                --total_buffers_;
+                bytes_allocated_ -= (*it)->capacity;
+                it = deq.erase(it);
+                ++cleaned_count;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+    
+    if (cleaned_count > 0)
+    {
+        LOG(DEBUG, LOG_TAG) << "Cleaned up " << cleaned_count << " stale buffers\n";
+    }
+}
+
+void DynamicBufferPool::check_cleanup()
+{
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_cleanup_ >= CLEANUP_INTERVAL)
+    {
+        cleanup(DEFAULT_MAX_IDLE);
+    }
+}
+
+DynamicBufferPool& DynamicBufferPool::instance()
+{
+    static DynamicBufferPool instance_;
+    return instance_;
+}

--- a/common/buffer_pool.cpp
+++ b/common/buffer_pool.cpp
@@ -29,9 +29,7 @@
 static constexpr auto LOG_TAG = "BufferPool";
 
 DynamicBufferPool::DynamicBufferPool(size_t initial_count, size_t default_buffer_size)
-    : default_buffer_size_(std::max(default_buffer_size, MIN_BUFFER_SIZE))
-    , initial_count_(initial_count)
-    , last_cleanup_(std::chrono::steady_clock::now())
+    : default_buffer_size_(std::max(default_buffer_size, MIN_BUFFER_SIZE)), initial_count_(initial_count), last_cleanup_(std::chrono::steady_clock::now())
 {
     // Lazy pre-allocation on first acquire
     LOG(DEBUG, LOG_TAG) << "Initialized buffer pool (lazy) with default size " << default_buffer_size_ << "\n";
@@ -40,12 +38,12 @@ DynamicBufferPool::DynamicBufferPool(size_t initial_count, size_t default_buffer
 DynamicBufferPool::BufferGuard DynamicBufferPool::acquire(size_t min_size)
 {
     check_cleanup();
-    
+
     size_t target_size = std::max({min_size, default_buffer_size_, MIN_BUFFER_SIZE});
     size_t size_bucket = get_size_bucket(target_size);
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Lazy initial allocation
     if (available_buffers_.empty() && initial_count_ > 0)
     {
@@ -54,9 +52,9 @@ DynamicBufferPool::BufferGuard DynamicBufferPool::acquire(size_t min_size)
             auto buffer = create_buffer(default_buffer_size_);
             available_buffers_[size_bucket].push_back(std::move(buffer));
         }
-        initial_count_ = 0;  // Prevent repeated allocation
+        initial_count_ = 0; // Prevent repeated allocation
     }
-    
+
     // Try to reuse an existing buffer from the same or larger size bucket
     auto it = available_buffers_.lower_bound(size_bucket);
     while (it != available_buffers_.end())
@@ -65,44 +63,43 @@ DynamicBufferPool::BufferGuard DynamicBufferPool::acquire(size_t min_size)
         {
             auto buffer = std::move(it->second.back());
             it->second.pop_back();
-            
+
             buffer->resize_if_needed(target_size);
             ++buffers_reused_;
-            
-            LOG(TRACE, LOG_TAG) << "Reused buffer from size bucket " << it->first 
-                                << " for requested size " << target_size << "\n";
-            
-            return { *this, std::move(buffer) };
+
+            LOG(TRACE, LOG_TAG) << "Reused buffer from size bucket " << it->first << " for requested size " << target_size << "\n";
+
+            return {*this, std::move(buffer)};
         }
         ++it;
     }
-    
+
     // No suitable buffer found, create a new one
     auto buffer = create_buffer(target_size);
     ++buffers_created_;
-    
+
     LOG(TRACE, LOG_TAG) << "Created new buffer of size " << target_size << "\n";
-    
-    return { *this, std::move(buffer) };
+
+    return {*this, std::move(buffer)};
 }
 
 void DynamicBufferPool::release(std::unique_ptr<Buffer> buffer)
 {
     if (!buffer)
         return;
-        
+
     check_cleanup();
-    
+
     size_t size_bucket = get_size_bucket(buffer->capacity);
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Check if we have room in this size bucket
     if (available_buffers_[size_bucket].size() < MAX_POOL_SIZE)
     {
         buffer->last_used = std::chrono::steady_clock::now();
         available_buffers_[size_bucket].push_back(std::move(buffer));
-        
+
         LOG(TRACE, LOG_TAG) << "Returned buffer to pool, size bucket " << size_bucket << "\n";
     }
     else
@@ -110,9 +107,8 @@ void DynamicBufferPool::release(std::unique_ptr<Buffer> buffer)
         // Pool is full for this size, let buffer be destroyed
         --total_buffers_;
         bytes_allocated_ -= buffer->capacity;
-        
-        LOG(TRACE, LOG_TAG) << "Pool full for size bucket " << size_bucket 
-                            << ", destroying buffer\n";
+
+        LOG(TRACE, LOG_TAG) << "Pool full for size bucket " << size_bucket << ", destroying buffer\n";
     }
 }
 
@@ -136,20 +132,20 @@ size_t DynamicBufferPool::get_size_bucket(size_t size)
 DynamicBufferPool::Stats DynamicBufferPool::getStats() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     Stats stats;
     stats.total_buffers = total_buffers_;
     stats.bytes_allocated = bytes_allocated_;
     stats.buffers_created = buffers_created_;
     stats.buffers_reused = buffers_reused_;
     stats.cleanup_operations = cleanup_operations_;
-    
+
     // Count available buffers
     for (const auto& bucket : available_buffers_)
     {
         stats.available_buffers += bucket.second.size();
     }
-    
+
     return stats;
 }
 
@@ -167,13 +163,13 @@ void DynamicBufferPool::cleanup(std::chrono::seconds max_idle_time)
     std::lock_guard<std::mutex> lock(mutex_);
     last_cleanup_ = now;
     ++cleanup_operations_;
-    
+
     size_t cleaned_count = 0;
-    
+
     for (auto& bucket_pair : available_buffers_)
     {
         auto& deq = bucket_pair.second;
-        for (auto it = deq.begin(); it != deq.end(); )
+        for (auto it = deq.begin(); it != deq.end();)
         {
             if (now - (*it)->last_used >= max_idle_time)
             {
@@ -188,7 +184,7 @@ void DynamicBufferPool::cleanup(std::chrono::seconds max_idle_time)
             }
         }
     }
-    
+
     if (cleaned_count > 0)
     {
         LOG(DEBUG, LOG_TAG) << "Cleaned up " << cleaned_count << " stale buffers\n";
@@ -202,12 +198,8 @@ void DynamicBufferPool::cleanup(std::chrono::seconds max_idle_time)
     }
 
     LOG(DEBUG, LOG_TAG) << "Buffer pool stats: "
-                        << "total=" << total_buffers_
-                        << ", available=" << available_count
-                        << ", created=" << buffers_created_
-                        << ", reused=" << buffers_reused_
-                        << ", bytes=" << bytes_allocated_
-                        << ", cleanups=" << cleanup_operations_ << "\n";
+                        << "total=" << total_buffers_ << ", available=" << available_count << ", created=" << buffers_created_ << ", reused=" << buffers_reused_
+                        << ", bytes=" << bytes_allocated_ << ", cleanups=" << cleanup_operations_ << "\n";
 }
 
 void DynamicBufferPool::check_cleanup()

--- a/common/buffer_pool.cpp
+++ b/common/buffer_pool.cpp
@@ -193,6 +193,21 @@ void DynamicBufferPool::cleanup(std::chrono::seconds max_idle_time)
     {
         LOG(DEBUG, LOG_TAG) << "Cleaned up " << cleaned_count << " stale buffers\n";
     }
+
+    // Log buffer pool statistics at DEBUG level
+    size_t available_count = 0;
+    for (const auto& bucket : available_buffers_)
+    {
+        available_count += bucket.second.size();
+    }
+
+    LOG(DEBUG, LOG_TAG) << "Buffer pool stats: "
+                        << "total=" << total_buffers_
+                        << ", available=" << available_count
+                        << ", created=" << buffers_created_
+                        << ", reused=" << buffers_reused_
+                        << ", bytes=" << bytes_allocated_
+                        << ", cleanups=" << cleanup_operations_ << "\n";
 }
 
 void DynamicBufferPool::check_cleanup()

--- a/common/buffer_pool.hpp
+++ b/common/buffer_pool.hpp
@@ -1,0 +1,221 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+#define NOMINMAX
+
+// standard headers
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <deque>
+#include <vector>
+#include <chrono>
+#include <map>
+
+/// Dynamic buffer pool for reducing memory allocations in message sending
+/**
+ * Thread-safe buffer pool that provides reusable buffers for message serialization.
+ * - Dynamically grows when buffers are exhausted
+ * - Buffers are returned after use for reuse
+ * - Supports different buffer sizes through size buckets
+ * - Thread-safe operations for multi-client scenarios
+ * - Automatic buffer cleanup and pool shrinkage
+ */
+class DynamicBufferPool
+{
+public:
+    /// Individual buffer wrapper with metadata
+    struct Buffer
+    {
+        /// @brief Actual buffer data
+        std::vector<char> data;
+        /// @brief Current capacity of the buffer
+        size_t capacity;
+        /// @brief Last used timestamp for cleanup purposes
+        std::chrono::steady_clock::time_point last_used;
+        
+        /// @brief c'tor for buffer of given size
+        /// @param size Initial size of the buffer
+        explicit Buffer(size_t size) 
+            : data(size)
+            , capacity(size)
+            , last_used(std::chrono::steady_clock::now())
+        {
+        }
+        
+        /// @brief Resize buffer if needed
+        /// @param new_size 
+        void resize_if_needed(size_t new_size)
+        {
+            if (new_size > capacity)
+            {
+                data.resize(new_size);
+                capacity = new_size;
+            }
+            else
+            {
+                data.resize(new_size);
+            }
+            last_used = std::chrono::steady_clock::now();
+        }
+    };
+    
+    /// RAII wrapper for automatic buffer return
+    class BufferGuard
+    {
+    public:
+        /// @brief c'tor
+        /// @param pool Underlying buffer pool
+        /// @param buffer Underlying buffer
+        BufferGuard(DynamicBufferPool& pool, std::unique_ptr<Buffer> buffer)
+            : pool_(pool), buffer_(std::move(buffer))
+        {
+        }
+        
+        /// @brief d'tor returns buffer to pool
+        ~BufferGuard()
+        {
+            if (buffer_)
+                pool_.release(std::move(buffer_));
+        }
+        
+        /// @brief Copy constructor deleted
+        /// No copying, only moving
+        BufferGuard(const BufferGuard&) = delete;
+
+        /// @brief Move assignment operator deleted
+        /// No copying, only moving
+        BufferGuard& operator=(const BufferGuard&) = delete;
+        
+        /// @brief Move constructor
+        BufferGuard(BufferGuard&& other) noexcept
+            : pool_(other.pool_), buffer_(std::move(other.buffer_))
+        {
+        }
+        
+        /// @brief Move assignment operator
+        BufferGuard& operator=(BufferGuard&& other) noexcept
+        {
+            if (this != &other)
+            {
+                if (buffer_)
+                    pool_.release(std::move(buffer_));
+                buffer_ = std::move(other.buffer_);
+            }
+            return *this;
+        }
+        
+        /// @brief Access underlying buffer data
+        std::vector<char>& get() { return buffer_->data; }
+
+        /// @brief Access underlying buffer data (const)
+        const std::vector<char>& get() const { return buffer_->data; }
+        
+        /// @brief Resize underlying buffer if needed
+        void resize(size_t size) { buffer_->resize_if_needed(size); }
+        
+    private:
+        DynamicBufferPool& pool_;
+        std::unique_ptr<Buffer> buffer_;
+    };
+
+    /// c'tor
+    explicit DynamicBufferPool(size_t initial_count = 16, size_t default_buffer_size = 4096);
+    
+    /// d'tor
+    ~DynamicBufferPool() = default;
+    
+    /// Acquire a buffer of at least the specified size
+    BufferGuard acquire(size_t min_size = 0);
+    
+    /// Get pool statistics
+    struct Stats
+    {
+        /// @brief Total number of buffers managed by the pool
+        size_t total_buffers{0};
+
+        /// @brief Total bytes allocated across all buffers
+        size_t available_buffers{0};
+
+        /// @brief Total bytes currently allocated
+        size_t bytes_allocated{0};
+
+        /// @brief Total number of buffers created since pool initialization
+        size_t buffers_created{0};
+
+        /// @brief Total number of buffers reused from the pool
+        size_t buffers_reused{0};
+
+        /// @brief Total number of cleanup operations performed
+        size_t cleanup_operations{0};
+    };
+    
+    /// @brief Get current pool statistics
+    /// @return Stats structure with current statistics
+    Stats getStats() const;
+
+    /// @brief Reset statistics counters
+    /// Note: This does not affect the actual pool or allocated buffers
+    void resetStats();
+    
+    /// Force cleanup of old unused buffers
+    void cleanup(std::chrono::seconds max_idle_time = std::chrono::seconds(300));
+    
+    /// Get singleton instance
+    static DynamicBufferPool& instance();
+
+private:
+    /// Release a buffer back to the pool
+    void release(std::unique_ptr<Buffer> buffer);
+    
+    /// Create new buffer
+    std::unique_ptr<Buffer> create_buffer(size_t size);
+    
+    /// Size bucket determination
+    static size_t get_size_bucket(size_t size);
+    
+    /// Check and perform cleanup if needed
+    void check_cleanup();
+    
+    // Configuration
+    static constexpr size_t MAX_POOL_SIZE = 128;      // Maximum buffers per size bucket
+    static constexpr size_t GROWTH_FACTOR = 2;       // Buffer size growth factor
+    static constexpr size_t MIN_BUFFER_SIZE = 1024;  // Minimum buffer size
+    static constexpr auto CLEANUP_INTERVAL = std::chrono::seconds(30);
+    static constexpr auto DEFAULT_MAX_IDLE = std::chrono::seconds(300);
+    
+    // Thread safety
+    mutable std::mutex mutex_;
+    
+    // Storage - map from size bucket to available buffers
+    std::map<size_t, std::deque<std::unique_ptr<Buffer>>> available_buffers_;
+    
+    // Statistics
+    size_t total_buffers_{0};
+    size_t bytes_allocated_{0};
+    size_t buffers_created_{0};
+    size_t buffers_reused_{0};
+    size_t cleanup_operations_{0};
+    
+    // Pool configuration
+    size_t default_buffer_size_;
+    size_t initial_count_;
+    std::chrono::steady_clock::time_point last_cleanup_;
+};

--- a/common/buffer_pool.hpp
+++ b/common/buffer_pool.hpp
@@ -22,12 +22,12 @@
 
 // standard headers
 #include <atomic>
+#include <chrono>
+#include <deque>
+#include <map>
 #include <memory>
 #include <mutex>
-#include <deque>
 #include <vector>
-#include <chrono>
-#include <map>
 
 /// Dynamic buffer pool for reducing memory allocations in message sending
 /**
@@ -50,18 +50,15 @@ public:
         size_t capacity;
         /// @brief Last used timestamp for cleanup purposes
         std::chrono::steady_clock::time_point last_used;
-        
+
         /// @brief c'tor for buffer of given size
         /// @param size Initial size of the buffer
-        explicit Buffer(size_t size) 
-            : data(size)
-            , capacity(size)
-            , last_used(std::chrono::steady_clock::now())
+        explicit Buffer(size_t size) : data(size), capacity(size), last_used(std::chrono::steady_clock::now())
         {
         }
-        
+
         /// @brief Resize buffer if needed
-        /// @param new_size 
+        /// @param new_size
         void resize_if_needed(size_t new_size)
         {
             if (new_size > capacity)
@@ -76,7 +73,7 @@ public:
             last_used = std::chrono::steady_clock::now();
         }
     };
-    
+
     /// RAII wrapper for automatic buffer return
     class BufferGuard
     {
@@ -84,18 +81,17 @@ public:
         /// @brief c'tor
         /// @param pool Underlying buffer pool
         /// @param buffer Underlying buffer
-        BufferGuard(DynamicBufferPool& pool, std::unique_ptr<Buffer> buffer)
-            : pool_(pool), buffer_(std::move(buffer))
+        BufferGuard(DynamicBufferPool& pool, std::unique_ptr<Buffer> buffer) : pool_(pool), buffer_(std::move(buffer))
         {
         }
-        
+
         /// @brief d'tor returns buffer to pool
         ~BufferGuard()
         {
             if (buffer_)
                 pool_.release(std::move(buffer_));
         }
-        
+
         /// @brief Copy constructor deleted
         /// No copying, only moving
         BufferGuard(const BufferGuard&) = delete;
@@ -103,13 +99,12 @@ public:
         /// @brief Move assignment operator deleted
         /// No copying, only moving
         BufferGuard& operator=(const BufferGuard&) = delete;
-        
+
         /// @brief Move constructor
-        BufferGuard(BufferGuard&& other) noexcept
-            : pool_(other.pool_), buffer_(std::move(other.buffer_))
+        BufferGuard(BufferGuard&& other) noexcept : pool_(other.pool_), buffer_(std::move(other.buffer_))
         {
         }
-        
+
         /// @brief Move assignment operator
         BufferGuard& operator=(BufferGuard&& other) noexcept
         {
@@ -121,16 +116,25 @@ public:
             }
             return *this;
         }
-        
+
         /// @brief Access underlying buffer data
-        std::vector<char>& get() { return buffer_->data; }
+        std::vector<char>& get()
+        {
+            return buffer_->data;
+        }
 
         /// @brief Access underlying buffer data (const)
-        const std::vector<char>& get() const { return buffer_->data; }
-        
+        const std::vector<char>& get() const
+        {
+            return buffer_->data;
+        }
+
         /// @brief Resize underlying buffer if needed
-        void resize(size_t size) { buffer_->resize_if_needed(size); }
-        
+        void resize(size_t size)
+        {
+            buffer_->resize_if_needed(size);
+        }
+
     private:
         DynamicBufferPool& pool_;
         std::unique_ptr<Buffer> buffer_;
@@ -138,13 +142,13 @@ public:
 
     /// c'tor
     explicit DynamicBufferPool(size_t initial_count = 16, size_t default_buffer_size = 4096);
-    
+
     /// d'tor
     ~DynamicBufferPool() = default;
-    
+
     /// Acquire a buffer of at least the specified size
     BufferGuard acquire(size_t min_size = 0);
-    
+
     /// Get pool statistics
     struct Stats
     {
@@ -166,7 +170,7 @@ public:
         /// @brief Total number of cleanup operations performed
         size_t cleanup_operations{0};
     };
-    
+
     /// @brief Get current pool statistics
     /// @return Stats structure with current statistics
     Stats getStats() const;
@@ -174,46 +178,46 @@ public:
     /// @brief Reset statistics counters
     /// Note: This does not affect the actual pool or allocated buffers
     void resetStats();
-    
+
     /// Force cleanup of old unused buffers
     void cleanup(std::chrono::seconds max_idle_time = std::chrono::seconds(300));
-    
+
     /// Get singleton instance
     static DynamicBufferPool& instance();
 
 private:
     /// Release a buffer back to the pool
     void release(std::unique_ptr<Buffer> buffer);
-    
+
     /// Create new buffer
     std::unique_ptr<Buffer> create_buffer(size_t size);
-    
+
     /// Size bucket determination
     static size_t get_size_bucket(size_t size);
-    
+
     /// Check and perform cleanup if needed
     void check_cleanup();
-    
+
     // Configuration
-    static constexpr size_t MAX_POOL_SIZE = 128;      // Maximum buffers per size bucket
-    static constexpr size_t GROWTH_FACTOR = 2;       // Buffer size growth factor
-    static constexpr size_t MIN_BUFFER_SIZE = 1024;  // Minimum buffer size
+    static constexpr size_t MAX_POOL_SIZE = 128;    // Maximum buffers per size bucket
+    static constexpr size_t GROWTH_FACTOR = 2;      // Buffer size growth factor
+    static constexpr size_t MIN_BUFFER_SIZE = 1024; // Minimum buffer size
     static constexpr auto CLEANUP_INTERVAL = std::chrono::seconds(30);
     static constexpr auto DEFAULT_MAX_IDLE = std::chrono::seconds(300);
-    
+
     // Thread safety
     mutable std::mutex mutex_;
-    
+
     // Storage - map from size bucket to available buffers
     std::map<size_t, std::deque<std::unique_ptr<Buffer>>> available_buffers_;
-    
+
     // Statistics
     size_t total_buffers_{0};
     size_t bytes_allocated_{0};
     size_t buffers_created_{0};
     size_t buffers_reused_{0};
     size_t cleanup_operations_{0};
-    
+
     // Pool configuration
     size_t default_buffer_size_;
     size_t initial_count_;

--- a/server/stream_session.hpp
+++ b/server/stream_session.hpp
@@ -21,6 +21,7 @@
 
 // local headers
 #include "authinfo.hpp"
+#include "common/buffer_pool.hpp"
 #include "common/message/message.hpp"
 #include "streamreader/stream_manager.hpp"
 
@@ -61,10 +62,14 @@ class shared_const_buffer
     /// the message
     struct Message
     {
-        std::vector<char> data;           ///< data
+        DynamicBufferPool::BufferGuard buffer_guard; ///< pooled buffer for data
+        size_t data_size;                 ///< actual size of data in buffer
         bool is_pcm_chunk;                ///< is it a PCM chunk
         message_type type;                ///< message type
         chronos::time_point_clk rec_time; ///< recording time
+        
+        Message(DynamicBufferPool::BufferGuard&& guard, size_t size) 
+            : buffer_guard(std::move(guard)), data_size(size) {}
     };
 
 public:
@@ -74,17 +79,28 @@ public:
         tv t;
         message.sent = t;
         const msg::PcmChunk* pcm_chunk = dynamic_cast<const msg::PcmChunk*>(&message);
-        message_ = std::make_shared<Message>();
+        
+        // Serialize message to get size
+        std::ostringstream oss;
+        message.serialize(oss);
+        std::string s = oss.str();
+        
+        // Acquire buffer from pool
+        auto buffer_guard = DynamicBufferPool::instance().acquire(s.size());
+        
+        // Copy data to pooled buffer
+        buffer_guard.resize(s.size());
+        std::copy(s.begin(), s.end(), buffer_guard.get().begin());
+        
+        // Create Message with pooled buffer
+        message_ = std::make_shared<Message>(std::move(buffer_guard), s.size());
         message_->type = message.type;
         message_->is_pcm_chunk = (pcm_chunk != nullptr);
         if (message_->is_pcm_chunk)
             message_->rec_time = pcm_chunk->start();
 
-        std::ostringstream oss;
-        message.serialize(oss);
-        std::string s = oss.str();
-        message_->data = std::vector<char>(s.begin(), s.end());
-        buffer_ = boost::asio::buffer(message_->data);
+        // Set up boost::asio buffer pointing to pooled data
+        buffer_ = boost::asio::buffer(message_->buffer_guard.get().data(), message_->data_size);
     }
 
     /// const buffer.

--- a/server/stream_session.hpp
+++ b/server/stream_session.hpp
@@ -63,13 +63,14 @@ class shared_const_buffer
     struct Message
     {
         DynamicBufferPool::BufferGuard buffer_guard; ///< pooled buffer for data
-        size_t data_size;                 ///< actual size of data in buffer
-        bool is_pcm_chunk;                ///< is it a PCM chunk
-        message_type type;                ///< message type
-        chronos::time_point_clk rec_time; ///< recording time
-        
-        Message(DynamicBufferPool::BufferGuard&& guard, size_t size) 
-            : buffer_guard(std::move(guard)), data_size(size) {}
+        size_t data_size;                            ///< actual size of data in buffer
+        bool is_pcm_chunk;                           ///< is it a PCM chunk
+        message_type type;                           ///< message type
+        chronos::time_point_clk rec_time;            ///< recording time
+
+        Message(DynamicBufferPool::BufferGuard&& guard, size_t size) : buffer_guard(std::move(guard)), data_size(size)
+        {
+        }
     };
 
 public:
@@ -79,19 +80,19 @@ public:
         tv t;
         message.sent = t;
         const msg::PcmChunk* pcm_chunk = dynamic_cast<const msg::PcmChunk*>(&message);
-        
+
         // Serialize message to get size
         std::ostringstream oss;
         message.serialize(oss);
         std::string s = oss.str();
-        
+
         // Acquire buffer from pool
         auto buffer_guard = DynamicBufferPool::instance().acquire(s.size());
-        
+
         // Copy data to pooled buffer
         buffer_guard.resize(s.size());
         std::copy(s.begin(), s.end(), buffer_guard.get().begin());
-        
+
         // Create Message with pooled buffer
         message_ = std::make_shared<Message>(std::move(buffer_guard), s.size());
         message_->type = message.type;


### PR DESCRIPTION
This is an updated version of my PR #1438.

I did some profiling on snapcast (while working on https://github.com/snapcast/snapcast/issues/1423). From my measurements, I concluded that a dynamic buffer pool for audio data would increase the performance.

Hence this is such a dynamic buffer pool. It is at common/buffer_pool.* that makes it possible to use it in server and client. However, this PR only uses it for TCP in the server (for shared_const_buffer). But I guess it could be used in the client for for WS as well.