### PR TITLE
feat: Add UDP/RTP stream source with jitter buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Please follow this [guide](doc/build.md) to build Snapcast for
 - [webOS](doc/build.md#webos-cross-compile)
 - [Windows](doc/build.md#windows-vcpkg)
 
-
 ## Configuration
 
 After installation, Snapserver and Snapclient are started with the command line arguments that are configured in `/etc/default/snapserver` and `/etc/default/snapclient`.
@@ -107,6 +106,7 @@ Available stream sources are:
 - [tcp](doc/configuration.md#tcp-server): receives audio from a TCP socket, can act as client or server
 - [pipewire](doc/configuration.md#pipewire): direct audio capture from PipeWire
 - [jack](doc/configuration.md#jack): receives audio from a Jack server
+- [udp](doc/configuration.md#udp-server): receives audio from a UDP socket (PCM, RTP)
 - [meta](doc/configuration.md#meta): read and mix audio from other stream sources
 
 ### Client
@@ -115,20 +115,20 @@ The client will use as audio backend the system's low level audio API to have th
 
 Available audio backends are configured using the `--player` command line parameter:
 
-| Backend   | OS      | Description  | Parameters |
-| --------- | ------- | ------------ | ---------- |
-| alsa      | Linux   | ALSA | `buffer_time=<total buffer size [ms]>` (default 80, min 10)<br>`fragments=<number of buffers>` (default 4, min 2) |
-| pulse     | Linux   | PulseAudio | `buffer_time=<buffer size [ms]>` (default 100, min 10)<br>`server=<PulseAudio server>` - default not-set: use the default server<br>`property=<key>=<value>` set PA property, can be used multiple times (default `media.role=music`)  |
-| oboe      | Android | Oboe, using OpenSL ES on Android 4.1 and AAudio on 8.1 | |
-| opensl    | Android | OpenSL ES | |
-| coreaudio | macOS   | Core Audio | |
-| wasapi    | Windows | Windows Audio Session API | |
-| sld2      | All     | SDL2 Audio (e.g. for LG webOS TVs) | |
-| file      | All     | Write audio to file | `filename=<filename>` (`<filename>` = `stdout`, `stderr`, `null` or a filename)<br>`mode=[w\|a]` (`w`: write (discarding the content), `a`: append (keeping the content) |
+| Backend   | OS      | Description                                            | Parameters                                                                                                                                                                                                                            |
+| --------- | ------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| alsa      | Linux   | ALSA                                                   | `buffer_time=<total buffer size [ms]>` (default 80, min 10)<br>`fragments=<number of buffers>` (default 4, min 2)                                                                                                                     |
+| pulse     | Linux   | PulseAudio                                             | `buffer_time=<buffer size [ms]>` (default 100, min 10)<br>`server=<PulseAudio server>` - default not-set: use the default server<br>`property=<key>=<value>` set PA property, can be used multiple times (default `media.role=music`) |
+| oboe      | Android | Oboe, using OpenSL ES on Android 4.1 and AAudio on 8.1 |                                                                                                                                                                                                                                       |
+| opensl    | Android | OpenSL ES                                              |                                                                                                                                                                                                                                       |
+| coreaudio | macOS   | Core Audio                                             |                                                                                                                                                                                                                                       |
+| wasapi    | Windows | Windows Audio Session API                              |                                                                                                                                                                                                                                       |
+| sld2      | All     | SDL2 Audio (e.g. for LG webOS TVs)                     |                                                                                                                                                                                                                                       |
+| file      | All     | Write audio to file                                    | `filename=<filename>` (`<filename>` = `stdout`, `stderr`, `null` or a filename)<br>`mode=[w\|a]` (`w`: write (discarding the content), `a`: append (keeping the content)                                                              |
 
 Parameters are appended to the player name, e.g. `--player alsa:buffer_time=100`. Use `--player <name>:?` to get a list of available options.  
 For some audio backends you can configure the PCM device using the `-s` or `--soundcard` parameter, the device is chosen by index or name. Available PCM devices can be listed with `-l` or `--list`  
-If you are running MPD and Shairport-sync into a soundcard that only supports 48000 sample rate, you can use `--sampleformat <arg>` and the snapclient will resample the audio from shairport-sync, for example, which is 44100 (i.e.  `--sampleformat 48000:16:*`)
+If you are running MPD and Shairport-sync into a soundcard that only supports 48000 sample rate, you can use `--sampleformat <arg>` and the snapclient will resample the audio from shairport-sync, for example, which is 44100 (i.e. `--sampleformat 48000:16:*`)
 
 ## Test
 
@@ -148,7 +148,7 @@ source = file:///home/user/Musik/Some%20wave%20file.wav?name=test
 
 When you are using a Raspberry Pi, you might have to change your audio output to the 3.5mm jack:
 
-``` shell
+```shell
 # The last number is the audio output with 1 being the 3.5 jack, 2 being HDMI and 0 being auto.
 amixer cset numid=3 1
 ```
@@ -233,14 +233,14 @@ This [guide](doc/player_setup.md) shows how to configure different players/audio
 
 Unordered list of features that should make it into the v1.0
 
-- [X] **Remote control** JSON-RPC API to change client latency, volume, zone,...
-- [X] **Android client** JSON-RPC client and Snapclient
-- [X] **Streams** Support multiple streams
-- [X] **Debian packages** prebuild deb packages
-- [X] **Endian** independent code
-- [X] **OpenWrt** port Snapclient to OpenWrt
-- [X] **Hi-Res audio** support (like 96kHz 24bit)
-- [X] **Groups** support multiple Groups of clients ("Zones")
-- [X] **Ports** Snapclient for Windows, Mac OS X,...
+- [x] **Remote control** JSON-RPC API to change client latency, volume, zone,...
+- [x] **Android client** JSON-RPC client and Snapclient
+- [x] **Streams** Support multiple streams
+- [x] **Debian packages** prebuild deb packages
+- [x] **Endian** independent code
+- [x] **OpenWrt** port Snapclient to OpenWrt
+- [x] **Hi-Res audio** support (like 96kHz 24bit)
+- [x] **Groups** support multiple Groups of clients ("Zones")
+- [x] **Ports** Snapclient for Windows, Mac OS X,...
 - [ ] **JSON-RPC** Possibility to add, remove, rename streams
 - [ ] **Protocol specification** Snapcast binary streaming protocol, JSON-RPC protocol

--- a/common/message/pcm_chunk.hpp
+++ b/common/message/pcm_chunk.hpp
@@ -51,6 +51,18 @@ public:
     /// d'tor
     ~PcmChunk() override = default;
 
+    /// copy c'tor
+    PcmChunk(const PcmChunk&) = default;
+
+    /// copy assignment
+    PcmChunk& operator=(const PcmChunk&) = default;
+
+    /// move c'tor
+    PcmChunk(PcmChunk&&) = default;
+
+    /// move assignment
+    PcmChunk& operator=(PcmChunk&&) = default;
+
 #if 0
     template <class Rep, class Period>
     int readFrames(void* outputBuffer, const std::chrono::duration<Rep, Period>& duration)

--- a/common/message/wire_chunk.hpp
+++ b/common/message/wire_chunk.hpp
@@ -53,10 +53,54 @@ public:
         memcpy(payload, wireChunk.payload, payloadSize);
     }
 
+    /// copy assignment
+    WireChunk& operator=(const WireChunk& other)
+    {
+        if (this != &other)
+        {
+            BaseMessage::operator=(other);
+            timestamp = other.timestamp;
+
+            if (payloadSize != other.payloadSize)
+            {
+                free(payload);
+                payloadSize = other.payloadSize;
+                payload = (payloadSize > 0) ? static_cast<char*>(malloc(payloadSize)) : nullptr;
+            }
+            if (payload && other.payload)
+                memcpy(payload, other.payload, payloadSize);
+        }
+        return *this;
+    }
+
     /// d'tor
     ~WireChunk() override
     {
         free(payload);
+    }
+
+    /// move c'tor
+    WireChunk(WireChunk&& other) noexcept
+        : BaseMessage(std::move(other)), timestamp(std::move(other.timestamp)), payloadSize(other.payloadSize), payload(other.payload)
+    {
+        other.payload = nullptr;
+        other.payloadSize = 0;
+    }
+
+    /// move assignment
+    WireChunk& operator=(WireChunk&& other) noexcept
+    {
+        if (this != &other)
+        {
+            free(payload);
+            timestamp = std::move(other.timestamp);
+            payloadSize = other.payloadSize;
+            payload = other.payload;
+
+            other.payload = nullptr;
+            other.payloadSize = 0;
+        }
+        return *this;
     }
 
     void read(std::istream& stream) override

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SERVER_SOURCES
     streamreader/stream_manager.cpp
     streamreader/pcm_stream.cpp
     streamreader/tcp_stream.cpp
+    streamreader/udp_stream.cpp
     streamreader/pipe_stream.cpp
     streamreader/file_stream.cpp
     streamreader/airplay_stream.cpp

--- a/server/streamreader/stream_manager.cpp
+++ b/server/streamreader/stream_manager.cpp
@@ -38,6 +38,7 @@
 #include "pipe_stream.hpp"
 #include "process_stream.hpp"
 #include "tcp_stream.hpp"
+#include "udp_stream.hpp"
 
 // 3rd party headers
 
@@ -127,6 +128,10 @@ PcmStreamPtr StreamManager::addStream(StreamUri& streamUri, PcmStream::Source so
     else if (streamUri.scheme == "tcp")
     {
         stream = make_shared<TcpStream>(listener, io_context_, settings_, streamUri, source);
+    }
+    else if (streamUri.scheme == "udp")
+    {
+        stream = make_shared<UdpStream>(listener, io_context_, settings_, streamUri, source);
     }
 #ifdef HAS_PIPEWIRE
     else if (streamUri.scheme == "pipewire")

--- a/server/streamreader/udp_stream.cpp
+++ b/server/streamreader/udp_stream.cpp
@@ -180,8 +180,8 @@ UdpStream::RtpHeader UdpStream::parse_rtp_header(const char* data, size_t len)
     if (len < 12)
         return header; // Caller ensures length
 
-    uint8_t b0 = static_cast<uint8_t>(data[0]);
-    uint8_t b1 = static_cast<uint8_t>(data[1]);
+    auto b0 = static_cast<uint8_t>(data[0]);
+    auto b1 = static_cast<uint8_t>(data[1]);
 
     header.version = (b0 >> 6) & 0x03;
     header.padding = (b0 >> 5) & 0x01;

--- a/server/streamreader/udp_stream.cpp
+++ b/server/streamreader/udp_stream.cpp
@@ -1,0 +1,355 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "udp_stream.hpp"
+#include "common/aixlog.hpp"
+#include "common/str_compat.hpp"
+#include <algorithm>
+#include <arpa/inet.h>
+#include <cstring>
+
+using namespace std;
+
+namespace streamreader
+{
+
+static constexpr auto kUriBufferMs = "buffer_ms";
+static constexpr auto kUriIdleThreshold = "idle_threshold";
+
+
+UdpStream::UdpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& ioc, const ServerSettings& server_settings, const StreamUri& uri,
+                     PcmStream::Source source)
+    : PcmStream(pcmListener, ioc, server_settings, uri, source), state_timer_(strand_), sap_timer_(strand_)
+{
+    // Default buffer_ms to 50ms if not specified, similar to other streams
+    if (uri_.query.find(kUriBufferMs) == uri_.query.end())
+        uri_.query[kUriBufferMs] = "50";
+
+    buffer_ms_ = std::max(cpt::stoi(uri_.getQuery(kUriBufferMs, "50")), 0);
+    idle_threshold_ = std::chrono::milliseconds(std::max(cpt::stoi(uri_.getQuery(kUriIdleThreshold, "100")), 10));
+
+    // Determine if RTP mode is enabled (default to true if not specified, or checks scheme/params)
+    is_rtp_ = uri_.getQuery("mode") == "rtp";
+
+    recv_buffer_.resize(65536); // Max UDP size
+}
+
+
+UdpStream::~UdpStream()
+{
+    stop();
+}
+
+
+void UdpStream::start()
+{
+    PcmStream::start();
+
+    try
+    {
+        udp::resolver resolver(strand_.get_inner_executor());
+        udp::endpoint endpoint = *resolver.resolve(udp::v4(), uri_.host, std::to_string(uri_.port.value_or(0))).begin();
+
+        socket_ = std::make_unique<udp::socket>(strand_.get_inner_executor());
+        socket_->open(endpoint.protocol());
+        socket_->bind(endpoint);
+
+        LOG(INFO, "UdpStream") << "Listening on " << endpoint << "\n";
+
+        do_read(); // Start reading
+
+        // Setup SAP announcement if requested
+        if (is_rtp_ || uri_.getQuery("sap") == "true")
+        {
+            sap_socket_ = std::make_unique<udp::socket>(strand_.get_inner_executor(), udp::endpoint(udp::v4(), 0));
+            sap_endpoint_ = *resolver.resolve(udp::v4(), "224.2.127.254", "9875").begin();
+            send_sap_announcement();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        LOG(ERROR, "UdpStream") << "Failed to start UDP stream: " << e.what() << "\n";
+        setState(ReaderState::kDisabled);
+    }
+}
+
+
+void UdpStream::stop()
+{
+    if (socket_)
+    {
+        socket_->close();
+        socket_.reset();
+    }
+    if (sap_socket_)
+    {
+        sap_socket_->close();
+        sap_socket_.reset();
+    }
+    state_timer_.cancel();
+    sap_timer_.cancel();
+    PcmStream::stop();
+}
+
+
+void UdpStream::do_read()
+{
+    if (!socket_)
+        return;
+
+    // Extend idle check
+    check_state(idle_threshold_ + std::chrono::milliseconds(chunk_ms_));
+
+    socket_->async_receive_from(boost::asio::buffer(recv_buffer_), remote_endpoint_,
+                                boost::asio::bind_executor(strand_,
+                                                           [this, self = shared_from_this()](boost::system::error_code ec, std::size_t bytes_transferred)
+    { handle_receive(ec, bytes_transferred); }));
+}
+
+
+void UdpStream::handle_receive(const boost::system::error_code& error, size_t bytes_transferred)
+{
+    state_timer_.cancel();
+
+    if (error)
+    {
+        if (error == boost::asio::error::operation_aborted)
+            return;
+        LOG(ERROR, "UdpStream") << "Receive error: " << error.message() << "\n";
+        do_read();
+        return;
+    }
+
+    if (is_rtp_)
+    {
+        if (bytes_transferred >= 12)
+        {
+            RtpHeader header = parse_rtp_header(recv_buffer_.data(), bytes_transferred);
+            process_rtp_packet(header, recv_buffer_.data(), bytes_transferred);
+        }
+    }
+    else
+    {
+        // Raw UDP handling
+        int frame_count = static_cast<int>(bytes_transferred / sampleFormat_.frameSize());
+        size_t effective_len = frame_count * sampleFormat_.frameSize();
+
+        if (frame_count > 0)
+        {
+            msg::PcmChunk packetChunk(sampleFormat_, 0);
+            packetChunk.setFrameCount(frame_count);
+            std::memcpy(packetChunk.payload, recv_buffer_.data(), effective_len);
+
+            if (isSilent(packetChunk))
+            {
+                silence_ += packetChunk.duration<std::chrono::microseconds>();
+                if (silence_ >= idle_threshold_)
+                    setState(ReaderState::kIdle);
+            }
+            else
+            {
+                silence_ = std::chrono::microseconds(0);
+                setState(ReaderState::kPlaying);
+            }
+
+            chunkRead(packetChunk);
+        }
+    }
+
+    do_read();
+}
+
+UdpStream::RtpHeader UdpStream::parse_rtp_header(const char* data, size_t len)
+{
+    RtpHeader header;
+    if (len < 12)
+        return header; // Caller ensures length
+
+    uint8_t b0 = static_cast<uint8_t>(data[0]);
+    uint8_t b1 = static_cast<uint8_t>(data[1]);
+
+    header.version = (b0 >> 6) & 0x03;
+    header.padding = (b0 >> 5) & 0x01;
+    header.extension = (b0 >> 4) & 0x01;
+    header.csrcCount = b0 & 0x0F;
+
+    header.marker = (b1 >> 7) & 0x01;
+    header.payloadType = b1 & 0x7F;
+
+    uint16_t seq;
+    std::memcpy(&seq, data + 2, 2);
+    header.sequenceNumber = ntohs(seq);
+
+    uint32_t ts;
+    std::memcpy(&ts, data + 4, 4);
+    header.timestamp = ntohl(ts);
+
+    uint32_t ssrc;
+    std::memcpy(&ssrc, data + 8, 4);
+    header.ssrc = ntohl(ssrc);
+
+    return header;
+}
+
+void UdpStream::process_rtp_packet(const RtpHeader& header, const char* data, size_t len)
+{
+    size_t header_len = 12 + (header.csrcCount * 4);
+    if (len < header_len)
+        return;
+
+    size_t payload_len = len - header_len;
+    int frame_count = static_cast<int>(payload_len / sampleFormat_.frameSize());
+
+    if (frame_count <= 0)
+        return;
+
+    msg::PcmChunk chunk(sampleFormat_, 0);
+    chunk.setFrameCount(frame_count);
+    std::memcpy(chunk.payload, data + header_len, frame_count * sampleFormat_.frameSize());
+
+    if (first_packet_)
+    {
+        next_sequence_number_ = header.sequenceNumber;
+        first_packet_ = false;
+    }
+
+    // Insert into jitter buffer
+    jitter_buffer_[header.sequenceNumber] = std::move(chunk);
+
+    pop_from_buffer();
+}
+
+void UdpStream::pop_from_buffer()
+{
+    // Max buffer depth (heuristic). Assuming ~20ms packets, 50ms buffer -> ~3 packets.
+    // We add a safety margin because latency is better than skips.
+    size_t max_packets = (buffer_ms_ / 20) + 10;
+
+    // Loop to process consecutive packets
+    int loops = 0;
+    while (loops++ < 1000) // Safety break
+    {
+        if (jitter_buffer_.empty())
+            break;
+
+        auto it = jitter_buffer_.find(next_sequence_number_);
+        if (it != jitter_buffer_.end())
+        {
+            // Found expected packet
+            msg::PcmChunk& chunk = it->second;
+
+            if (isSilent(chunk))
+            {
+                silence_ += chunk.duration<std::chrono::microseconds>();
+                if (silence_ >= idle_threshold_)
+                    setState(ReaderState::kIdle);
+            }
+            else
+            {
+                silence_ = std::chrono::microseconds(0);
+                setState(ReaderState::kPlaying);
+            }
+
+            chunkRead(chunk);
+            jitter_buffer_.erase(it);
+            next_sequence_number_++;
+        }
+        else
+        {
+            // Check if buffer is too full (latency check)
+            if (jitter_buffer_.size() > max_packets)
+            {
+                // Drop missing packet, advance expectation
+                next_sequence_number_++;
+            }
+            else
+            {
+                // Wait for packet
+                break;
+            }
+        }
+    }
+}
+
+
+void UdpStream::check_state(const std::chrono::steady_clock::duration& duration)
+{
+    state_timer_.expires_after(duration);
+    state_timer_.async_wait([this, self = shared_from_this()](const boost::system::error_code& ec)
+    {
+        if (!ec)
+        {
+            setState(ReaderState::kIdle);
+        }
+    });
+}
+
+
+void UdpStream::send_sap_announcement()
+{
+    if (!sap_socket_)
+        return;
+
+    // SAP Header: V=1, A=0, R=0, T=0, E=0, C=0 -> 0x20
+
+    // SDP Payload
+    std::string sdp = "v=0\r\n";
+    sdp += "o=- " + std::to_string(std::chrono::system_clock::now().time_since_epoch().count()) + " 0 IN IP4 " + uri_.host + "\r\n";
+    sdp += "s=" + name_ + "\r\n";
+    sdp += "c=IN IP4 " + uri_.host + "\r\n";
+    sdp += "t=0 0\r\n";
+    sdp += "m=audio " + std::to_string(uri_.port.value_or(0)) + " RTP/AVP " + (is_rtp_ ? "96" : "10") + "\r\n";
+
+    if (is_rtp_)
+        sdp += "a=rtpmap:96 L16/" + std::to_string(sampleFormat_.rate()) + "/" + std::to_string(sampleFormat_.channels()) + "\r\n";
+
+
+    // SAP Packet Construction
+    std::vector<uint8_t> packet;
+    packet.push_back(0x20); // V=1, IPv4
+    packet.push_back(0x00); // No Auth
+    packet.push_back(0x12); // MsgId Hash
+    packet.push_back(0x34);
+
+    // IP Origin (4 bytes) - 0.0.0.0
+    packet.push_back(0);
+    packet.push_back(0);
+    packet.push_back(0);
+    packet.push_back(0);
+
+    // MIME type string "application/sdp\0"
+    std::string mime = "application/sdp";
+    packet.insert(packet.end(), mime.begin(), mime.end());
+    packet.push_back(0);
+
+    // SDP
+    packet.insert(packet.end(), sdp.begin(), sdp.end());
+
+    sap_socket_->async_send_to(boost::asio::buffer(packet), sap_endpoint_, [this, self = shared_from_this()](const boost::system::error_code&, std::size_t)
+    {
+        // Re-schedule
+        sap_timer_.expires_after(std::chrono::seconds(10));
+        sap_timer_.async_wait([this, self](const boost::system::error_code& ec)
+        {
+            if (!ec)
+                send_sap_announcement();
+        });
+    });
+}
+
+} // namespace streamreader

--- a/server/streamreader/udp_stream.cpp
+++ b/server/streamreader/udp_stream.cpp
@@ -176,7 +176,7 @@ void UdpStream::handle_receive(const boost::system::error_code& error, size_t by
 
 UdpStream::RtpHeader UdpStream::parse_rtp_header(const char* data, size_t len)
 {
-    RtpHeader header;
+    RtpHeader header{};
     if (len < 12)
         return header; // Caller ensures length
 

--- a/server/streamreader/udp_stream.cpp
+++ b/server/streamreader/udp_stream.cpp
@@ -40,7 +40,7 @@ UdpStream::UdpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& 
     if (uri_.query.find(kUriBufferMs) == uri_.query.end())
         uri_.query[kUriBufferMs] = "50";
 
-    buffer_ms_ = std::max(cpt::stoi(uri_.getQuery(kUriBufferMs, "50")), 0);
+    buffer_ms_ = static_cast<uint32_t>(std::max(cpt::stoi(uri_.getQuery(kUriBufferMs, "50")), 0));
     idle_threshold_ = std::chrono::milliseconds(std::max(cpt::stoi(uri_.getQuery(kUriIdleThreshold, "100")), 10));
 
     // Determine if RTP mode is enabled (default to true if not specified, or checks scheme/params)
@@ -52,7 +52,7 @@ UdpStream::UdpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& 
 
 UdpStream::~UdpStream()
 {
-    stop();
+    UdpStream::stop();
 }
 
 
@@ -208,7 +208,7 @@ UdpStream::RtpHeader UdpStream::parse_rtp_header(const char* data, size_t len)
 
 void UdpStream::process_rtp_packet(const RtpHeader& header, const char* data, size_t len)
 {
-    size_t header_len = 12 + (header.csrcCount * 4);
+    size_t header_len = 12 + static_cast<size_t>(header.csrcCount * 4);
     if (len < header_len)
         return;
 

--- a/server/streamreader/udp_stream.hpp
+++ b/server/streamreader/udp_stream.hpp
@@ -1,0 +1,95 @@
+/***
+    This file is part of snapcast
+    Copyright (C) 2014-2025  Johannes Pohl
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#pragma once
+
+
+// local headers
+#include "asio_stream.hpp"
+
+// 3rd party headers
+#include <boost/asio/ip/udp.hpp>
+
+using boost::asio::ip::udp;
+
+
+namespace streamreader
+{
+
+/// Reads and decodes PCM data from a UDP socket
+/**
+ * Reads PCM from a UDP socket and passes the data to an encoder.
+ * Implements EncoderListener to get the encoded data.
+ * Data is passed to the PcmStream::Listener
+ */
+class UdpStream : public PcmStream
+{
+public:
+    /// c'tor. Encoded PCM data is passed to the Listener
+    UdpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& ioc, const ServerSettings& server_settings, const StreamUri& uri,
+              PcmStream::Source source);
+    ~UdpStream() override;
+
+    void start() override;
+    void stop() override;
+
+protected:
+    void do_read();
+    void handle_receive(const boost::system::error_code& error, size_t bytes_transferred);
+    void check_state(const std::chrono::steady_clock::duration& duration);
+    void on_timer(const boost::system::error_code& ec);
+
+    struct RtpHeader
+    {
+        uint8_t version;
+        bool padding;
+        bool extension;
+        uint8_t csrcCount;
+        bool marker;
+        uint8_t payloadType;
+        uint16_t sequenceNumber;
+        uint32_t timestamp;
+        uint32_t ssrc;
+    };
+
+    std::unique_ptr<udp::socket> socket_;
+    udp::endpoint remote_endpoint_;
+    std::vector<char> recv_buffer_;
+    boost::asio::steady_timer state_timer_;
+    boost::asio::steady_timer sap_timer_;
+    std::chrono::microseconds silence_{0};
+    std::chrono::milliseconds idle_threshold_;
+    bool is_rtp_{false};
+
+    // Jitter buffer
+    std::map<uint16_t, msg::PcmChunk> jitter_buffer_;
+    uint16_t next_sequence_number_{0};
+    bool first_packet_{true};
+    uint32_t buffer_ms_{50}; // Jitter buffer latency config
+
+    void process_rtp_packet(const RtpHeader& header, const char* payload, size_t len);
+    void pop_from_buffer();
+    RtpHeader parse_rtp_header(const char* data, size_t len);
+
+    // SAP announcements
+    void send_sap_announcement();
+    std::unique_ptr<udp::socket> sap_socket_;
+    udp::endpoint sap_endpoint_;
+};
+
+} // namespace streamreader

--- a/server/streamreader/udp_stream.hpp
+++ b/server/streamreader/udp_stream.hpp
@@ -54,17 +54,18 @@ protected:
     void check_state(const std::chrono::steady_clock::duration& duration);
     void on_timer(const boost::system::error_code& ec);
 
+    /// RTP Header structure (RFC 3550)
     struct RtpHeader
     {
-        uint8_t version{0};
-        bool padding{false};
-        bool extension{false};
-        uint8_t csrcCount{0};
-        bool marker{false};
-        uint8_t payloadType{0};
-        uint16_t sequenceNumber{0};
-        uint32_t timestamp{0};
-        uint32_t ssrc{0};
+        uint8_t version{0};         ///< Protocol version
+        bool padding{false};        ///< Padding flag
+        bool extension{false};      ///< Extension flag
+        uint8_t csrcCount{0};       ///< CSRC count
+        bool marker{false};         ///< Marker bit
+        uint8_t payloadType{0};     ///< Payload type
+        uint16_t sequenceNumber{0}; ///< Sequence number
+        uint32_t timestamp{0};      ///< Timestamp
+        uint32_t ssrc{0};           ///< Synchronization source identifier
     };
 
     std::unique_ptr<udp::socket> socket_;
@@ -82,8 +83,13 @@ protected:
     bool first_packet_{true};
     uint32_t buffer_ms_{50}; // Jitter buffer latency config
 
+    /// Processes a parsed RTP packet and adds it to the jitter buffer
     void process_rtp_packet(const RtpHeader& header, const char* payload, size_t len);
+
+    /// Pops available packets from the jitter buffer and sends them to the encoder
     void pop_from_buffer();
+
+    /// Parses the RTP header from the received data
     RtpHeader parse_rtp_header(const char* data, size_t len);
 
     // SAP announcements

--- a/server/streamreader/udp_stream.hpp
+++ b/server/streamreader/udp_stream.hpp
@@ -20,8 +20,8 @@
 
 
 // local headers
-#include "asio_stream.hpp"
 #include "common/message/pcm_chunk.hpp"
+#include "pcm_stream.hpp"
 
 // 3rd party headers
 #include <boost/asio/ip/udp.hpp>
@@ -34,11 +34,11 @@
 #include <string>
 #include <vector>
 
-using boost::asio::ip::udp;
-
 
 namespace streamreader
 {
+
+using boost::asio::ip::udp;
 
 /// Reads and decodes PCM data from a UDP socket
 /**

--- a/server/streamreader/udp_stream.hpp
+++ b/server/streamreader/udp_stream.hpp
@@ -21,9 +21,18 @@
 
 // local headers
 #include "asio_stream.hpp"
+#include "common/message/pcm_chunk.hpp"
 
 // 3rd party headers
 #include <boost/asio/ip/udp.hpp>
+#include <boost/asio/steady_timer.hpp>
+
+// standard headers
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 using boost::asio::ip::udp;
 
@@ -49,10 +58,17 @@ public:
     void stop() override;
 
 protected:
+    /// Asynchronous read operation
     void do_read();
+
+    /// Handle received data
+    /// @param error Error code
+    /// @param bytes_transferred Number of bytes received
     void handle_receive(const boost::system::error_code& error, size_t bytes_transferred);
+
+    /// Check stream state (playing/idle)
+    /// @param duration Time to wait before next check
     void check_state(const std::chrono::steady_clock::duration& duration);
-    void on_timer(const boost::system::error_code& ec);
 
     /// RTP Header structure (RFC 3550)
     struct RtpHeader
@@ -68,34 +84,41 @@ protected:
         uint32_t ssrc{0};           ///< Synchronization source identifier
     };
 
-    std::unique_ptr<udp::socket> socket_;
-    udp::endpoint remote_endpoint_;
-    std::vector<char> recv_buffer_;
-    boost::asio::steady_timer state_timer_;
-    boost::asio::steady_timer sap_timer_;
-    std::chrono::microseconds silence_{0};
-    std::chrono::milliseconds idle_threshold_;
-    bool is_rtp_{false};
+    std::unique_ptr<udp::socket> socket_;      ///< UDP socket
+    udp::endpoint remote_endpoint_;            ///< Sender endpoint
+    std::vector<char> recv_buffer_;            ///< Receive buffer
+    boost::asio::steady_timer state_timer_;    ///< Timer for state checking
+    boost::asio::steady_timer sap_timer_;      ///< Timer for SAP announcements
+    std::chrono::microseconds silence_{0};     ///< Accumulated silence duration
+    std::chrono::milliseconds idle_threshold_; ///< Threshold to switch to idle state
+    bool is_rtp_{false};                       ///< RTP mode flag
 
     // Jitter buffer
-    std::map<uint16_t, msg::PcmChunk> jitter_buffer_;
-    uint16_t next_sequence_number_{0};
-    bool first_packet_{true};
-    uint32_t buffer_ms_{50}; // Jitter buffer latency config
+    std::map<uint16_t, msg::PcmChunk> jitter_buffer_; ///< Jitter buffer (seq -> chunk)
+    uint16_t next_sequence_number_{0};                ///< Next expected sequence number
+    bool first_packet_{true};                         ///< Flag for first packet
+    uint32_t buffer_ms_{50};                          ///< Jitter buffer latency config
 
     /// Processes a parsed RTP packet and adds it to the jitter buffer
+    /// @param header Parsed RTP header
+    /// @param payload Pointer to the RTP payload
+    /// @param len Length of the payload
     void process_rtp_packet(const RtpHeader& header, const char* payload, size_t len);
 
     /// Pops available packets from the jitter buffer and sends them to the encoder
     void pop_from_buffer();
 
     /// Parses the RTP header from the received data
+    /// @param data Pointer to the packet data
+    /// @param len Length of the packet data
+    /// @return Parsed RTP header
     RtpHeader parse_rtp_header(const char* data, size_t len);
 
     // SAP announcements
+    /// Sends a SAP announcement
     void send_sap_announcement();
-    std::unique_ptr<udp::socket> sap_socket_;
-    udp::endpoint sap_endpoint_;
+    std::unique_ptr<udp::socket> sap_socket_; ///< Socket for SAP announcements
+    udp::endpoint sap_endpoint_;              ///< SAP multicast endpoint
 };
 
 } // namespace streamreader

--- a/server/streamreader/udp_stream.hpp
+++ b/server/streamreader/udp_stream.hpp
@@ -56,15 +56,15 @@ protected:
 
     struct RtpHeader
     {
-        uint8_t version;
-        bool padding;
-        bool extension;
-        uint8_t csrcCount;
-        bool marker;
-        uint8_t payloadType;
-        uint16_t sequenceNumber;
-        uint32_t timestamp;
-        uint32_t ssrc;
+        uint8_t version{0};
+        bool padding{false};
+        bool extension{false};
+        uint8_t csrcCount{0};
+        bool marker{false};
+        uint8_t payloadType{0};
+        uint16_t sequenceNumber{0};
+        uint32_t timestamp{0};
+        uint32_t ssrc{0};
     };
 
     std::unique_ptr<udp::socket> socket_;


### PR DESCRIPTION
# Feature: UDP/RTP Stream Source

## Description

This PR introduces a new `udp://` stream source, enabling Snapcast to receive audio via UDP packets. This includes support for raw PCM over UDP as well as RTP (Real-time Transport Protocol) with basic jitter buffering and reordering capabilities.

## Motivation

While Snapcast's internal TCP-based protocol is excellent for synchronized distribution, there are use cases where pushing audio to the server via UDP is desirable (e.g., from simple IoT devices, FFmpeg broadcasting, or other RTP-capable sources). This implementation provides a specialized input source for such scenarios, adhering to Snapcast's architecture.

## Key Features

- **UDP Source**: Receives audio on a specified port.
- **RTP Support**: Handles RTP v2 headers, including stripping and parsing (Sequence Number, Timestamp).
- **Jitter Buffer**: Implements a configurable jitter buffer (default 50ms) to reorder out-of-sequence packets and smooth out network jitter.
- **SAP Announcements**: Automatically announces the stream via SAP/SDP for easy discovery by clients (e.g., VLC).
- **Configuration**:
  - URI Scheme: `udp://<host>:<port>`
  - Parameters: `mode=rtp` (enable RTP), `buffer_ms=<ms>` (jitter buffer latency), `sap=true` (force SAP).

## Usage Example

**Server Configuration (`snapserver.conf`):**

```ini
[stream]
source = udp://0.0.0.0:4455?name=MyStream&mode=rtp&buffer_ms=80
```

**Streaming to Snapcast (e.g., via FFmpeg):**

```bash
ffmpeg -re -i input.mp3 -acodec pcm_s16le -f rtp udp://<snapserver_ip>:4455
```

## Related issues
Accomplish feature request from issue #909