### PR TITLE
Allow passing additional parameters to pipewire

### DIFF
--- a/client/player/pipewire_player.cpp
+++ b/client/player/pipewire_player.cpp
@@ -196,6 +196,18 @@ PipeWirePlayer::PipeWirePlayer(boost::asio::io_context& io_context, const Client
 
     if (params.find("buffer_time") != params.end())
         node_latency_ = std::chrono::milliseconds(std::max(cpt::stoi(params["buffer_time"].front()), 10));
+
+    // Collect custom PipeWire properties (any param that isn't a known snapclient option)
+    for (const auto& [key, values] : params)
+    {
+        if (key == "buffer_time")
+            continue;
+        if (!values.empty())
+        {
+            custom_props_[key] = values.front();
+            LOG(INFO, LOG_TAG) << "Custom PipeWire property: " << key << " = " << values.front() << "\n";
+        }
+    }
 }
 
 
@@ -452,6 +464,13 @@ void PipeWirePlayer::initPipewire()
         // PW_KEY_NODE_NAME, "TODO: Player name or instance id", 
         nullptr);
     // clang-format on
+
+    // Apply custom PipeWire properties from player parameters
+    for (const auto& [key, value] : custom_props_)
+    {
+        LOG(INFO, LOG_TAG) << "Setting custom property: " << key << " = " << value << "\n";
+        pw_properties_set(props, key.c_str(), value.c_str());
+    }
 
     if (node_latency_)
     {

--- a/client/player/pipewire_player.hpp
+++ b/client/player/pipewire_player.hpp
@@ -31,8 +31,10 @@
 // standard headers
 #include <chrono>
 #include <cstdio>
+#include <map>
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace player
 {
@@ -79,6 +81,9 @@ private:
     struct pw_stream_events stream_events_;
 
     std::optional<std::chrono::milliseconds> node_latency_;
+
+    /// Custom PipeWire properties from player parameters
+    std::map<std::string, std::string> custom_props_;
 };
 
 } // namespace player

--- a/doc/client/pipewire_player.md
+++ b/doc/client/pipewire_player.md
@@ -39,6 +39,8 @@ snapclient --player pipewire
 
 - `buffer_time`: Audio buffer time in milliseconds (default: 100ms, minimum: 10ms)
 
+Any additional parameters are passed directly as PipeWire properties on the stream node. This allows setting arbitrary PipeWire properties such as `media.role`, `node.name`, or any other property recognized by PipeWire and WirePlumber.
+
 ### Examples
 
 1. **Use default PipeWire sink:**
@@ -64,6 +66,21 @@ snapclient --player pipewire
    ```bash
    snapclient --player pipewire:buffer_time=200 --soundcard my_audio_device
    ```
+
+5. **Set custom PipeWire properties:**
+
+   ```bash
+   snapclient --player pipewire:media.role=Notification
+   ```
+
+6. **Multiple custom properties (for multi-instance routing):**
+
+   ```bash
+   snapclient --player pipewire:node.name=snapclient-kitchen,media.role=Music
+   snapclient --player pipewire:node.name=snapclient-alerts,media.role=Notification
+   ```
+
+   This allows WirePlumber to distinguish between instances and route them differently.
 
 ## Device Selection and Management
 

--- a/doc/pipewire-stream.md
+++ b/doc/pipewire-stream.md
@@ -44,6 +44,8 @@ source = pipewire://?name=Snapcast&device=&auto_connect=true
 - `send_silence`: Send silent chunks when idle (default: false)
 - `idle_threshold`: Duration of silence before switching to idle state in ms (default: 100)
 
+Any additional URI parameters are passed directly as PipeWire properties on the stream node. This allows setting arbitrary PipeWire properties such as `media.role`, `node.name`, `media.category`, or any other property recognized by PipeWire and WirePlumber.
+
 ### Examples
 
 1. **Capture from default source:**
@@ -69,6 +71,20 @@ source = pipewire://?name=Snapcast&device=&auto_connect=true
    ```ini
    source = pipewire://?name=SnapcastCapture&idle_threshold=500&send_silence=true
    ```
+
+5. **Set custom PipeWire properties:**
+
+   ```ini
+   source = pipewire://?name=SnapcastCapture&media.role=Communication
+   ```
+
+6. **Multiple custom properties (for multi-instance routing):**
+
+   ```ini
+   source = pipewire://?name=SnapcastKitchen&node.name=snapcast-kitchen-capture&media.role=Music
+   ```
+
+   This allows WirePlumber to distinguish between instances and route them differently.
 
 ## PipeWire Graph Management
 

--- a/server/streamreader/pipewire_stream.cpp
+++ b/server/streamreader/pipewire_stream.cpp
@@ -81,6 +81,15 @@ PipeWireStream::PipeWireStream(PcmStream::Listener* pcmListener, boost::asio::io
     idle_threshold_ = std::chrono::milliseconds(std::max(cpt::stoi(uri_.getQuery("idle_threshold", "100")), 10));
     capture_sink_ = (uri_.getQuery("capture_sink", "false") == "true");
 
+    // Collect custom PipeWire properties (any param that isn't a known stream option)
+    for (const auto& [key, value] : uri_.getQuery())
+    {
+        if (key == "name" || key == "target" || key == "send_silence" || key == "idle_threshold" || key == "capture_sink" || key == "chunk_ms" || key == "sampleformat" || key == "codec" || key == "controlscript" || key == "controlscriptparams" || key == "dryout_ms" || key == "stream_type")
+            continue;
+        custom_props_[key] = value;
+        LOG(INFO, LOG_TAG) << "Custom PipeWire property: " << key << " = " << value << "\n";
+    }
+
     // Initialize PipeWire
     pw_init(nullptr, nullptr);
 }
@@ -347,6 +356,13 @@ void PipeWireStream::initPipeWire()
     if (capture_sink_)
     {
         pw_properties_set(props, "stream.capture.sink", "true");
+    }
+
+    // Apply custom PipeWire properties from stream URI
+    for (const auto& [key, value] : custom_props_)
+    {
+        LOG(INFO, LOG_TAG) << "Setting custom property: " << key << " = " << value << "\n";
+        pw_properties_set(props, key.c_str(), value.c_str());
     }
 
     // Set latency

--- a/server/streamreader/pipewire_stream.hpp
+++ b/server/streamreader/pipewire_stream.hpp
@@ -29,6 +29,7 @@
 #include <spa/param/audio/raw.h>
 
 // standard headers
+#include <map>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -85,6 +86,7 @@ private:
     std::string target_device_;
     std::string stream_name_;
     bool capture_sink_;
+    std::map<std::string, std::string> custom_props_;
 
     // Audio buffer management
     std::mutex buffer_mutex_;


### PR DESCRIPTION
Allow passing of arbitrary pipewire parameters through both the server and client. This solves #1456
* * *

## Pull Request Checklist

* Contributions must be licensed under the [GPL-3.0 License](LICENSE)

* This project loosely follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)

* For better compatibility with embedded toolchains, the used C++ standard should be limited to C++17

* Code should be formatted by running `make reformat`

* Branch from the `develop` branch and ensure it is up to date with the current `develop` branch before submitting your pull request. If it doesn't merge cleanly with `develop`, you may be asked to resolve the conflicts. Pull requests to master will be closed.

* Commits should be as small as possible while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).

* Pull requests must not contain compiled sources (already set by the default .gitignore) or binary files

* Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests. If tested manually, provide information about the test scope in the PR description (e.g. “Test passed: Upgrade version from 0.42 to 0.42.23.”).

* Create _Work In Progress [WIP]_ pull requests only if you need clarification or an explicit review before you can continue your work item.

* If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review by contacting us via [email](mailto:snapcast@badaix.de).

* Post review:
  * If a review requires you to change your commit(s), please test the changes again.
  * Amend the affected commit(s) and force push onto your branch.
  * Set respective comments in your GitHub review to resolved.
  * Create a general PR comment to notify the reviewers that your amendments are ready for another round of review.
